### PR TITLE
Synchronize registry methods for thread safety

### DIFF
--- a/minject/registry.py
+++ b/minject/registry.py
@@ -64,6 +64,17 @@ class RegistryWrapper(Generic[T]):
             self._closed = True
 
 
+def _synchronized(func: Callable[P, R]) -> Callable[P, R]:
+    """Decorator to synchronize method access with a reentrant lock."""
+
+    @functools.wraps(func)
+    def wrapper(self: "Registry", *args: Any, **kwargs: Any) -> R:
+        with self._lock:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
 class Registry(Resolver):
     """Tracks and manages registered object instances."""
 
@@ -76,17 +87,6 @@ class Registry(Resolver):
         self._config = RegistryConfigWrapper()
 
         self._lock = RLock()
-
-    @staticmethod
-    def _synchronized(func: Callable[P, R]) -> Callable[P, R]:
-        """Decorator to synchronize method access with a reentrant lock."""
-
-        @functools.wraps(func)
-        def wrapper(self: "Registry", *args: Any, **kwargs: Any) -> R:
-            with self._lock:
-                return func(self, *args, **kwargs)
-
-        return wrapper
 
     @property
     def config(self) -> RegistryConfigWrapper:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,8 +1,7 @@
 import unittest
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from functools import cache
-from itertools import chain
+from functools import lru_cache
 from random import shuffle
 from typing import Sequence
 
@@ -520,7 +519,7 @@ class RegistryTestCase(unittest.TestCase):
         query_per_class = 2
         num_classes = num_queries // query_per_class
 
-        @cache
+        @lru_cache(maxsize=None)
         def new_type(i):
             return type(f"NewType{i}", (), {})
 


### PR DESCRIPTION
### Description

- Synchronized critical methods that modifies the internal state of the registry to prevent race conditions in concurrent object registrations.
- Synchronized lazy initialization to prevent multiple objects being instantiated for singleton classes.
- Added test cases

Not included
- Thread safety for methods outside the `Registry` class
- An RWLock implementation for potentially better performance. In fact, contentions within the registry should be very rare as the critical sections are short. Adding a `RWLock` might add complexity as well as an extra dependency

This PR should resolve #8

### Verification

#### Lazy initialization test
To trigger the race condition more reliably, checkout branch `thread-safety` and turn on this flag
https://github.com/duolingo/minject/blob/892e0d59d888816a40619a35d9ec0d7de3164330/minject/registry.py#L17

Run `hatch test`. Notice the test fails because some singleton classes may be instantiated twice.

```
>       assert all(count == query_per_class for count in conuter.values())
E       assert False
E        +  where False = all(<generator object RegistryTestCase.test_concurrent_lazy_init.<locals>.<genexpr> at 0x105578860>)

```

Now, turn on the flag for the fix

https://github.com/duolingo/minject/blob/892e0d59d888816a40619a35d9ec0d7de3164330/minject/registry.py#L18

All tests should reliably pass now.

#### Concurrent Get/Registration Tests

Because of non-deterministic interleavings, triggering race conditions for this case is difficult, although theoretically they are possible because at times we make updates to multiple shared data structures. The test cases are provided more to give a specification of the behaviors. Adding instructions to reliably trigger the potential bugs like the above might be a future task.