### PR TITLE
Update config namespace to `minject`

### DIFF
--- a/minject/config.py
+++ b/minject/config.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 # Unbound, invariant type variable
 T = TypeVar("T")
+CONFIG_NAMESPACE = "minject"
 
 
 class RegistrySubConfig(TypedDict, total=False):
@@ -67,7 +68,7 @@ class RegistryConfigWrapper:
         """Get init kwargs configured for a given RegistryMetadata."""
         result: Dict[str, Any] = {}
 
-        reg_conf: Optional[RegistrySubConfig] = self._impl.get("registry")
+        reg_conf: Optional[RegistrySubConfig] = self._impl.get(CONFIG_NAMESPACE)
         if reg_conf:
             by_class = reg_conf.get("by_class")
             if by_class and meta._cls:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -4,7 +4,7 @@ import importlib
 import logging
 from typing import Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
-from .config import RegistryConfigWrapper, RegistrySubConfig
+from .config import CONFIG_NAMESPACE, RegistryConfigWrapper, RegistrySubConfig
 from .metadata import RegistryMetadata, _get_meta, _get_meta_from_key
 from .model import RegistryKey, Resolvable, Resolver, resolve_value
 
@@ -81,7 +81,7 @@ class Registry(Resolver):
         return resolve_value(self, value)
 
     def _autostart_candidates(self) -> Iterable[RegistryKey]:
-        registry_config: Optional[RegistrySubConfig] = self.config.get("registry")
+        registry_config: Optional[RegistrySubConfig] = self.config.get(CONFIG_NAMESPACE)
         if registry_config:
             autostart = registry_config.get("autostart")
             if autostart:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -180,7 +180,7 @@ class RegistryTestCase(unittest.TestCase):
 
         self.registry.config.from_dict(
             {
-                "registry": {
+                "minject": {
                     "by_class": {"tests.test_registry_helpers.Border": {"style": "solid"}},
                     "by_name": {
                         "border_red": {"width": "2px"},
@@ -398,7 +398,7 @@ class RegistryTestCase(unittest.TestCase):
 
     def test_autostart(self) -> None:
         self.registry.config.from_dict(
-            {"registry": {"autostart": ["tests.test_registry_helpers.FakeWorker"]}}
+            {"minject": {"autostart": ["tests.test_registry_helpers.FakeWorker"]}}
         )
 
         self.registry.start()


### PR DESCRIPTION
### Desciption

Currently minject looks for registry configuration under the registry namespace. This name was chosen relative to the previous name of this library. This PR updates the namespace key to be "minject", the new library name.

### Verification

- `grep -r '"registry"' ./minject` returns nothing

Resolves #12
