### PR TITLE
Update code example references to remove "Duolingo"

### DIFF
--- a/docs/dependency_injection.md
+++ b/docs/dependency_injection.md
@@ -18,8 +18,8 @@ through dependency injection.
 Create and activate a virtual environment by running the following commands in your terminal:
 
 ```console
-python3 -m venv .pyenv
-source .pyenv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 ```
 
 Next, import `minject`:


### PR DESCRIPTION
### Description

- Updated links to examples in `dependency_inject.md` so that they use the latest commits free of Duolingo reference

### Verification

- Search the [file](https://github.com/duolingo/minject/blob/3ddd60efa10fde73a07c5129ebb2b2114c3db58e/docs/dependency_injection.md) and confirm that there's no Duolingo reference