### PR TITLE
Improve .gitignore coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,20 @@
 # Ignore PyCharm/IntelliJ IDEA files
 /.idea/
 
+# Ignore VSCode files
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
 *.pyc
 
 # python virtualenv
@@ -30,3 +44,4 @@ pylint.out
 /results.xml
 
 /lib/dist/
+/dist/


### PR DESCRIPTION
### Description

The existing `.gitignore` file only excludes the `.venv` folder. This pull request improves its coverage by using the template `.gitignore`.