### PR TITLE
Update `pyproject.toml` for `hatch test`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling >= 1.10.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]


### PR DESCRIPTION
### Description

- removed custom coverage script
    - hatch has a built-in command for test coverage `hatch test --cover`, and so perhaps we don't need 
to keep the special coverage script whose output is presumably only used by the jenkins bot
- defined `hatch-test` environment matrix
    - `hatch test` command uses the [`hatch-test` environment matrix](https://github.com/pypa/hatch/blob/3adae6c0dfd5c20dfe9bf6bae19b44a696c22a43/src/hatch/cli/test/__init__.py#L42) (instead of `test`), and that's why `hatch test` does the use the matrix we defined before
    
closes #30
    
### Verification

Run `hatch test --all` and see that it runs tests against both versions
