### PR TITLE
Add Async Support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,18 @@
+# Versioning
+
+`minject` uses semantic versioning. To learn more about semantic versioning, see the [semantic versioning specification](https://semver.org/#semantic-versioning-200).
+
+# Changelog
+
+## v1.1.0
+
+Add support for async Python. This version introduces the following methods and decorators:
+
+- `Registry.__aenter__`
+- `Registry.__aexit__`
+- `Registry.aget`
+- `@async_context`
+
+## v1.0.0
+
+- Initial Release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 # Changelog
 
-## v1.1.0
+## v1.1.0-beta.1
 
 Add support for async Python. This version introduces the following methods and decorators:
 

--- a/minject/__init__.py
+++ b/minject/__init__.py
@@ -44,7 +44,7 @@ registry['something_i_need'] = make_something()
 something = registry['something_i_need']
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.0-beta.1"
 
 from . import inject
 from .inject_attrs import inject_define as define, inject_field as field

--- a/minject/__init__.py
+++ b/minject/__init__.py
@@ -44,7 +44,7 @@ registry['something_i_need'] = make_something()
 something = registry['something_i_need']
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from . import inject
 from .inject_attrs import inject_define as define, inject_field as field

--- a/minject/asyncio_extensions.py
+++ b/minject/asyncio_extensions.py
@@ -17,7 +17,13 @@ except ImportError:
     # and moved it out of the try - except block
     # __all__ = "to_thread",
 
-    async def to_thread(func, /, *args, **kwargs):
+    # Minject Specific Edit: I removed the '/' from the function signature,
+    # as this is not supported in python 3.7 (added in python 3.8).
+    # The '/' forces that "func" be passed positionally (I.E. first argument
+    # to to_thread). Users of this extension must be careful to pass the
+    # function as the first argument.
+    # original asyncio source: "async def to_thread(func, /, *args, **kwargs):"
+    async def to_thread(func, *args, **kwargs):
         """Asynchronously run function *func* in a separate thread.
 
         Any *args and **kwargs supplied for this function are directly passed

--- a/minject/asyncio_extensions.py
+++ b/minject/asyncio_extensions.py
@@ -1,0 +1,36 @@
+"""
+This module provides fallback implementations of asyncio features that
+are not available in Python 3.7.
+"""
+
+try:
+    from asyncio import to_thread
+# This is copy pasted from here: https://github.com/python/cpython/blob/03775472cc69e150ced22dc30334a7a202fc0380/Lib/asyncio/threads.py#L1-L25
+except ImportError:
+    """High-level support for working with threads in asyncio"""
+
+    import contextvars
+    import functools
+    from asyncio import events
+
+    # Minject Specific Edit: I commented out the following line
+    # and moved it out of the try - except block
+    # __all__ = "to_thread",
+
+    async def to_thread(func, /, *args, **kwargs):
+        """Asynchronously run function *func* in a separate thread.
+
+        Any *args and **kwargs supplied for this function are directly passed
+        to *func*. Also, the current :class:`contextvars.Context` is propagated,
+        allowing context variables from the main thread to be accessed in the
+        separate thread.
+
+        Return a coroutine that can be awaited to get the eventual result of *func*.
+        """
+        loop = events.get_running_loop()
+        ctx = contextvars.copy_context()
+        func_call = functools.partial(ctx.run, func, *args, **kwargs)
+        return await loop.run_in_executor(None, func_call)
+
+
+__all__ = "to_thread"

--- a/minject/asyncio_extensions.py
+++ b/minject/asyncio_extensions.py
@@ -24,9 +24,10 @@ except ImportError:
     # The '/' forces that "func" be passed positionally (I.E. first argument
     # to to_thread). Users of this extension must be careful to pass the argument
     # to "func" positionally, or there could be different behavior
-    # when using minject in python 3.7 and python 3.9+.
+    # when using minject in python 3.7 and python 3.9+. I need to add a "type: ignore"
+    # to avoid mypy errors related to defining function with a different signature.
     # original asyncio source: "async def to_thread(func, /, *args, **kwargs):"
-    async def to_thread(func, *args, **kwargs):
+    async def to_thread(func, *args, **kwargs):  # type: ignore
         """Asynchronously run function *func* in a separate thread.
 
         Any *args and **kwargs supplied for this function are directly passed

--- a/minject/asyncio_extensions.py
+++ b/minject/asyncio_extensions.py
@@ -4,7 +4,9 @@ are not available in Python 3.7.
 """
 
 try:
-    from asyncio import to_thread
+    # Python 3.7 mypy raises attr-defined error for to_thread, so
+    # we must ignore it here.
+    from asyncio import to_thread  # type: ignore[attr-defined]
 # This is copy pasted from here: https://github.com/python/cpython/blob/03775472cc69e150ced22dc30334a7a202fc0380/Lib/asyncio/threads.py#L1-L25
 except ImportError:
     """High-level support for working with threads in asyncio"""
@@ -20,8 +22,9 @@ except ImportError:
     # Minject Specific Edit: I removed the '/' from the function signature,
     # as this is not supported in python 3.7 (added in python 3.8).
     # The '/' forces that "func" be passed positionally (I.E. first argument
-    # to to_thread). Users of this extension must be careful to pass the
-    # function as the first argument.
+    # to to_thread). Users of this extension must be careful to pass the argument
+    # to "func" positionally, or there could be different behavior
+    # when using minject in python 3.7 and python 3.9+.
     # original asyncio source: "async def to_thread(func, /, *args, **kwargs):"
     async def to_thread(func, *args, **kwargs):
         """Asynchronously run function *func* in a separate thread.

--- a/minject/asyncio_extensions.py
+++ b/minject/asyncio_extensions.py
@@ -24,8 +24,9 @@ except ImportError:
     # The '/' forces that "func" be passed positionally (I.E. first argument
     # to to_thread). Users of this extension must be careful to pass the argument
     # to "func" positionally, or there could be different behavior
-    # when using minject in python 3.7 and python 3.9+. I need to add a "type: ignore"
-    # to avoid mypy errors related to defining function with a different signature.
+    # when using minject in python 3.7 and python 3.9+. I added a "type: ignore"
+    # comment to silence mypy errors related to defining a function with a
+    # different signature.
     # original asyncio source: "async def to_thread(func, /, *args, **kwargs):"
     async def to_thread(func, *args, **kwargs):  # type: ignore
         """Asynchronously run function *func* in a separate thread.

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -1,5 +1,6 @@
 """Collection of annotations to define how a class should be initialized by the registry."""
 
+import asyncio
 import itertools
 import os
 from typing import (
@@ -152,7 +153,7 @@ class _RegistryReference(Deferred[T_co]):
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         if _is_key_async(self._key):
             return await registry_impl._aresolve(self._key)
-        return registry_impl.resolve(self._key)
+        return await asyncio.to_thread(registry_impl.resolve, self._key)
 
     @property
     def type_of_object_referenced_in_key(self) -> "Type[T_co]":
@@ -328,7 +329,7 @@ class _RegistryConfig(Deferred[T_co]):
             return cast(T_co, self._default)
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
-        return self.resolve(registry_impl)
+        return await asyncio.to_thread(self.resolve, registry_impl)
 
     @property
     def key(self) -> Optional[str]:
@@ -374,7 +375,7 @@ class _RegistryNestedConfig(Deferred[T_co]):
         return cast(T_co, sub)
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
-        return self.resolve(registry_impl)
+        return await asyncio.to_thread(self.resolve, registry_impl)
 
 
 def nested_config(
@@ -436,7 +437,7 @@ class _RegistrySelf(Deferred[Resolver]):
         return registry_impl
 
     async def aresolve(self, registry_impl: Resolver) -> Resolver:
-        return self.resolve(registry_impl)
+        return await asyncio.to_thread(self.resolve, registry_impl)
 
 
 self_tag = _RegistrySelf()

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -118,7 +118,7 @@ def _is_type(key: "RegistryKey[T]") -> TypeGuard[Type[T]]:
     return isinstance(key, type)
 
 
-def _is_key_async(key: RegistryKey) -> bool:
+def _is_key_async(key: "RegistryKey[T]") -> bool:
     """
     Check whether a registry key is an async context manager
     marked for initialization within the registry (@async_context).

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -150,9 +150,7 @@ class _RegistryReference(Deferred[T_co]):
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         if _is_key_async(self._key):
-            result = await registry_impl._aresolve(self._key)
-            await registry_impl._push_async_context(result)
-            return result
+            return await registry_impl._aresolve(self._key)
         return registry_impl.resolve(self._key)
 
     @property

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -123,9 +123,15 @@ def _is_type(key: "RegistryKey[T]") -> TypeGuard[Type[T]]:
 
 def _is_key_async(key: "RegistryKey[T]") -> bool:
     """
-    Check whether a registry key is an async context manager
-    marked for initialization within the registry (@async_context).
+    Check whether a registry key is an "async", or in other words
+    marked for async initialization within the registry with @async_context.
+    If a key is "async", it can be initialized through Registry.aget.
     """
+    # At present, we only consider objects with RegistryMetadata.is_async_context
+    # set to True to be "async", or able to be initialized through Registry.aget.
+    # In the future, we likely will support initializing both async and non-async
+    # objects through aget, but we are deferring implementing this until
+    # we have a bit more experience using the async Registry API.
     if isinstance(key, str):
         return False
     elif isinstance(key, RegistryMetadata):

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -2,9 +2,10 @@
 
 import itertools
 import os
-from typing import Any, Callable, Dict, Optional, Sequence, Type, TypeVar, Union, cast, overload
+from types import TracebackType
+from typing import Any, Callable, Dict, Optional, Protocol, Sequence, Type, TypeVar, Union, cast, overload
 
-from typing_extensions import TypeGuard
+from typing_extensions import TypeGuard, Self
 
 from .metadata import RegistryMetadata, _gen_meta, _get_meta
 from .model import (
@@ -16,8 +17,17 @@ from .model import (
 )
 from .types import _MinimalMappingProtocol
 
+class _AsyncContextProtocol(Protocol):
+    async def __aenter__(self : Self) -> Self:
+        ...
+
+    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+        ...
+
+
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
+T_async_context = TypeVar("T_async_context", bound=_AsyncContextProtocol)
 R = TypeVar("R")
 
 
@@ -52,7 +62,6 @@ def bind(
 ) -> Callable[[Type[T]], Type[T]]:
     ...
 
-
 def bind(
     _close=None,
     **bindings,
@@ -69,6 +78,8 @@ def bind(
 
     return wrap
 
+def async_context(cls : Type[T_async_context]) -> Type[T_async_context]:
+    return cls
 
 def define(
     base_class: Type[T],

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -150,8 +150,8 @@ class _RegistryReference(Deferred[T_co]):
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         if _is_key_async(self._key):
-            result = await registry_impl.aresolve(self._key)
-            await registry_impl.push_async_context(result)
+            result = await registry_impl._aresolve(self._key)
+            await registry_impl._push_async_context(result)
             return result
         return registry_impl.resolve(self._key)
 

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -152,14 +152,10 @@ class _RegistryReference(Deferred[T_co]):
         return registry_impl.resolve(self._key)
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
-        # TODO: this should needs to be able to tell if BOTH a TYPE
-        # or a RegistryMetadata is async. This means that given a type,
-        # we need to check that the metadata within the type if it exists.
         if is_key_async(self._key):
             result = await registry_impl.aresolve(self._key)
             await registry_impl.push_async_context(result)
             return result
-
         return registry_impl.resolve(self._key)
 
     @property

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -6,7 +6,6 @@ from types import TracebackType
 from typing import (
     Any,
     Callable,
-    Coroutine,
     Dict,
     Optional,
     Sequence,

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -86,14 +86,14 @@ def bind(
 
 def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
     """
-    Decorator to declare that a class is as an async context manager
+    Declare that a class is as an async context manager
     that can be initialized by the registry through aget(). This
     is to distinguish the class from an async context manager that
     should not be initialized by the registry (an example of
     this being asyncio.Lock).
     """
     meta = _gen_meta(cls)
-    meta.update_async_context(True)
+    meta.is_async_context = True
     return cls
 
 
@@ -126,13 +126,13 @@ def _is_key_async(key: "RegistryKey[T]") -> bool:
     if isinstance(key, str):
         return False
     elif isinstance(key, RegistryMetadata):
-        return key.is_async_context()
+        return key.is_async_context
     else:
-        assert_type(key, type)
+        assert_type(key, Type[T])
         inject_metadata = _get_meta(key)
         if inject_metadata is None:
             return False
-        return inject_metadata.is_async_context()
+        return inject_metadata.is_async_context
 
 
 class _RegistryReference(Deferred[T_co]):

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -87,9 +87,10 @@ def bind(
 def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
     """
     Decorator to declare that a class is as an async context manager
-    that can be initialized by the registry. This is to distinguish the
-    class from an async context manager that should not be initialized
-    by the registry (an example of this being asyncio.Lock()).
+    that can be initialized by the registry through aget(). This
+    is to distinguish the class from an async context manager that
+    should not be initialized by the registry (an example of
+    this being asyncio.Lock()).
     """
     meta = _gen_meta(cls)
     meta.update_async_context(True)

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -3,9 +3,22 @@
 import itertools
 import os
 from types import TracebackType
-from typing import Any, Callable, Coroutine, Dict, Optional, Protocol, Sequence, Type, TypeVar, Union, cast, overload
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Optional,
+    Protocol,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
-from typing_extensions import TypeGuard, Self
+from typing_extensions import Self, TypeGuard
 
 from .metadata import _INJECT_METADATA_ATTR, RegistryMetadata, _gen_meta, _get_meta
 from .model import (
@@ -13,16 +26,19 @@ from .model import (
     DeferredAny,
     RegistryKey,  # pylint: disable=unused-import
     Resolver,
-    resolve_value,
     aresolve_value,
+    resolve_value,
 )
 from .types import _MinimalMappingProtocol
 
+
 class _AsyncContextProtocol(Protocol):
-    async def __aenter__(self : Self) -> Self:
+    async def __aenter__(self: Self) -> Self:
         ...
 
-    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType
+    ) -> None:
         ...
 
 
@@ -63,6 +79,7 @@ def bind(
 ) -> Callable[[Type[T]], Type[T]]:
     ...
 
+
 def bind(
     _close=None,
     **bindings,
@@ -79,10 +96,12 @@ def bind(
 
     return wrap
 
-def async_context(cls : Type[T_async_context]) -> Type[T_async_context]:
+
+def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
     meta = _gen_meta(cls)
     meta.update_async_context(True)
     return cls
+
 
 def define(
     base_class: Type[T],
@@ -114,12 +133,13 @@ def is_key_async(key: RegistryKey) -> bool:
     elif isinstance(key, RegistryMetadata):
         return key.is_async_context()
     elif isinstance(key, type):
-        try: # type: ignore
+        try:  # type: ignore
             inject_metadata = object.__getattribute__(key, _INJECT_METADATA_ATTR)
-            return inject_metadata.is_async_context() # type: ignore
+            return inject_metadata.is_async_context()  # type: ignore
         except AttributeError:
             return False
     assert False, f"Unexpected key type: {key}"
+
 
 class _RegistryReference(Deferred[T_co]):
     """Reference to an object in the registry to be loaded later.
@@ -132,7 +152,7 @@ class _RegistryReference(Deferred[T_co]):
 
     def resolve(self, registry_impl: Resolver) -> T_co:
         return registry_impl.resolve(self._key)
-    
+
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         # TODO: this should needs to be able to tell if BOTH a TYPE
         # or a RegistryMetadata is async. This means that given a type,
@@ -228,7 +248,7 @@ class _RegistryFunction(Deferred[T_co]):
         for key, arg in self.kwargs.items():
             kwargs[key] = resolve_value(registry_impl, arg)
         return self.func()(*args, **kwargs)
-    
+
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         raise NotImplementedError("Have not implemented async registry function")
 
@@ -316,7 +336,6 @@ class _RegistryConfig(Deferred[T_co]):
             raise KeyError(self._key)
         else:
             return cast(T_co, self._default)
-    
 
     async def aresolve(self, registry_impl: Resolver) -> Coroutine[Any, Any, T_co]:
         raise NotImplementedError("Have not implemented async registry config")
@@ -363,7 +382,7 @@ class _RegistryNestedConfig(Deferred[T_co]):
             else:
                 return self._default
         return cast(T_co, sub)
-    
+
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         raise NotImplementedError("Have not implemented async registry nested config")
 
@@ -425,7 +444,7 @@ class _RegistrySelf(Deferred[Resolver]):
 
     def resolve(self, registry_impl: Resolver) -> Resolver:
         return registry_impl
-    
+
     async def aresolve(self, registry_impl: Resolver) -> Resolver:
         return registry_impl
 

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -9,7 +9,6 @@ from typing import (
     Coroutine,
     Dict,
     Optional,
-    Protocol,
     Sequence,
     Type,
     TypeVar,
@@ -18,7 +17,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self, TypeGuard
+from typing_extensions import Protocol, Self, TypeGuard
 
 from .metadata import _INJECT_METADATA_ATTR, RegistryMetadata, _gen_meta, _get_meta
 from .model import (

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -106,10 +106,10 @@ def define(
     """Create a new registry key based on a class and optional bindings."""
     meta = _get_meta(base_class)
     if meta:
-        is_async = meta.is_async_context
-        meta = RegistryMetadata(base_class, bindings=dict(meta.bindings))
+        meta = RegistryMetadata(
+            base_class, is_async_context=meta.is_async_context, bindings=dict(meta.bindings)
+        )
         meta.update_bindings(**bindings)
-        meta.is_async_context = is_async
     else:
         meta = RegistryMetadata(base_class, bindings=bindings)
     meta._close = _close

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -336,7 +336,7 @@ class _RegistryConfig(Deferred[T_co]):
         else:
             return cast(T_co, self._default)
 
-    async def aresolve(self, registry_impl: Resolver) -> Coroutine[Any, Any, T_co]:
+    async def aresolve(self, registry_impl: Resolver) -> T_co:
         raise NotImplementedError("Have not implemented async registry config")
 
     @property

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -105,8 +105,10 @@ def define(
     """Create a new registry key based on a class and optional bindings."""
     meta = _get_meta(base_class)
     if meta:
+        is_async = meta.is_async_context
         meta = RegistryMetadata(base_class, bindings=dict(meta.bindings))
         meta.update_bindings(**bindings)
+        meta.is_async_context = is_async
     else:
         meta = RegistryMetadata(base_class, bindings=bindings)
     meta._close = _close

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -1,6 +1,5 @@
 """Collection of annotations to define how a class should be initialized by the registry."""
 
-import asyncio
 import itertools
 import os
 from typing import (
@@ -18,6 +17,7 @@ from typing import (
 
 from typing_extensions import TypeGuard, assert_type
 
+from minject.asyncio_extensions import to_thread
 from minject.types import _AsyncContext
 
 from .metadata import _INJECT_METADATA_ATTR, RegistryMetadata, _gen_meta, _get_meta
@@ -159,7 +159,7 @@ class _RegistryReference(Deferred[T_co]):
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         if _is_key_async(self._key):
             return await registry_impl._aresolve(self._key)
-        return await asyncio.to_thread(registry_impl.resolve, self._key)
+        return await to_thread(registry_impl.resolve, self._key)
 
     @property
     def type_of_object_referenced_in_key(self) -> "Type[T_co]":
@@ -335,7 +335,7 @@ class _RegistryConfig(Deferred[T_co]):
             return cast(T_co, self._default)
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
-        return await asyncio.to_thread(self.resolve, registry_impl)
+        return await to_thread(self.resolve, registry_impl)
 
     @property
     def key(self) -> Optional[str]:
@@ -381,7 +381,7 @@ class _RegistryNestedConfig(Deferred[T_co]):
         return cast(T_co, sub)
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
-        return await asyncio.to_thread(self.resolve, registry_impl)
+        return await to_thread(self.resolve, registry_impl)
 
 
 def nested_config(
@@ -443,7 +443,7 @@ class _RegistrySelf(Deferred[Resolver]):
         return registry_impl
 
     async def aresolve(self, registry_impl: Resolver) -> Resolver:
-        return await asyncio.to_thread(self.resolve, registry_impl)
+        return await to_thread(self.resolve, registry_impl)
 
 
 self_tag = _RegistrySelf()

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -138,7 +138,9 @@ class _RegistryReference(Deferred[T_co]):
         # or a RegistryMetadata is async. This means that given a type,
         # we need to check that the metadata within the type if it exists.
         if is_key_async(self._key):
-            return await registry_impl.aresolve(self._key)
+            result = await registry_impl.aresolve(self._key)
+            await registry_impl.push_async_context(result)
+            return result
 
         return registry_impl.resolve(self._key)
 

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -143,7 +143,7 @@ class RegistryMetadata(Generic[T_co]):
         # TODO: 'lock' the bindings once added to the registry to make above note unnecessary
         self._bindings.update(bindings)
 
-    def update_async_context(self, is_async_context : bool) -> None:
+    def update_async_context(self, is_async_context: bool) -> None:
         self._is_async_context = is_async_context
 
     def is_async_context(self) -> bool:

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -143,17 +143,19 @@ class RegistryMetadata(Generic[T_co]):
         # TODO: 'lock' the bindings once added to the registry to make above note unnecessary
         self._bindings.update(bindings)
 
-    def update_async_context(self, is_async_context: bool) -> None:
-        """
-        Set the async context flag for this metadata.
-        """
-        self._is_async_context = is_async_context
-
+    @property
     def is_async_context(self) -> bool:
         """
         Returns the value of the async context flag for this metadata.
         """
         return self._is_async_context
+
+    @is_async_context.setter
+    def is_async_context(self, is_async_context: bool) -> None:
+        """
+        Set the async context flag for this metadata.
+        """
+        self._is_async_context = is_async_context
 
     def _new_object(self) -> T_co:
         return self._cls.__new__(self._cls)

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -14,7 +14,7 @@ from typing import (
     TypeVar,
 )
 
-from .model import DeferredAny, RegistryKey
+from .model import DeferredAny, RegistryKey, aresolve_value
 from .types import Kwargs
 
 if TYPE_CHECKING:
@@ -181,7 +181,7 @@ class RegistryMetadata(Generic[T_co]):
         """
         init_kwargs = {}
         for name_, value in self._bindings.items():
-            init_kwargs[name_] = await registry_impl._aresolve_resolvable(value)
+            init_kwargs[name_] = await aresolve_value(registry_impl, value)
         self._cls.__init__(obj, **init_kwargs)
 
     def _close_object(self, obj: T_co) -> None:  # type: ignore[misc]

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -144,9 +144,15 @@ class RegistryMetadata(Generic[T_co]):
         self._bindings.update(bindings)
 
     def update_async_context(self, is_async_context: bool) -> None:
+        """
+        Set the async context flag for this metadata.
+        """
         self._is_async_context = is_async_context
 
     def is_async_context(self) -> bool:
+        """
+        Returns the value of the async context flag for this metadata.
+        """
         return self._is_async_context
 
     def _new_object(self) -> T_co:
@@ -167,6 +173,9 @@ class RegistryMetadata(Generic[T_co]):
         self._cls.__init__(obj, **init_kwargs)
 
     async def _ainit_object(self, obj: T_co, registry_impl: "Registry") -> None:  # type: ignore[misc]
+        """
+        asynchronous version of _init_object. Calls _aresolve instead of resolve.
+        """
         init_kwargs = {}
         for name_, value in self._bindings.items():
             # the specific deferred value checks if they are async or

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -106,13 +106,14 @@ class RegistryMetadata(Generic[T_co]):
         cls: Type[T_co],
         close: Optional[Callable[[T_co], None]] = None,
         bindings: Optional[Kwargs] = None,
+        is_async_context: bool = False,
     ):
         self._cls = cls
         self._bindings = bindings or {}
 
         self._close = close
         self._interfaces = [cls for cls in inspect.getmro(cls) if cls is not object]
-        self._is_async_context = False
+        self.is_async_context = is_async_context
 
     @property
     def interfaces(self) -> Sequence[Type]:
@@ -142,20 +143,6 @@ class RegistryMetadata(Generic[T_co]):
         """
         # TODO: 'lock' the bindings once added to the registry to make above note unnecessary
         self._bindings.update(bindings)
-
-    @property
-    def is_async_context(self) -> bool:
-        """
-        Returns the value of the async context flag for this metadata.
-        """
-        return self._is_async_context
-
-    @is_async_context.setter
-    def is_async_context(self, is_async_context: bool) -> None:
-        """
-        Set the async context flag for this metadata.
-        """
-        self._is_async_context = is_async_context
 
     def _new_object(self) -> T_co:
         return self._cls.__new__(self._cls)

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -179,7 +179,6 @@ class RegistryMetadata(Generic[T_co]):
         """
         init_kwargs = {}
         for name_, value in self._bindings.items():
-            # the specific deferred value checks if they are async or
             init_kwargs[name_] = await registry_impl._aresolve(value)
         self._cls.__init__(obj, **init_kwargs)
 

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -179,7 +179,7 @@ class RegistryMetadata(Generic[T_co]):
         """
         init_kwargs = {}
         for name_, value in self._bindings.items():
-            init_kwargs[name_] = await registry_impl._aresolve(value)
+            init_kwargs[name_] = await registry_impl._aresolve_resolvable(value)
         self._cls.__init__(obj, **init_kwargs)
 
     def _close_object(self, obj: T_co) -> None:  # type: ignore[misc]

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -174,7 +174,8 @@ class RegistryMetadata(Generic[T_co]):
 
     async def _ainit_object(self, obj: T_co, registry_impl: "Registry") -> None:  # type: ignore[misc]
         """
-        asynchronous version of _init_object. Calls _aresolve instead of resolve.
+        asynchronous version of _init_object. Calls _aresolve instead
+        of _resolve.
         """
         init_kwargs = {}
         for name_, value in self._bindings.items():

--- a/minject/model.py
+++ b/minject/model.py
@@ -35,7 +35,7 @@ class Resolver(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def aresolve(self, key: "RegistryKey[T]") -> T:
+    async def _aresolve(self, key: "RegistryKey[T]") -> T:
         """
         Resolve a key into an instance of that key. The key must be marked
         with the @async_context decorator.
@@ -43,7 +43,7 @@ class Resolver(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def push_async_context(self, key: Any) -> Any:
+    async def _push_async_context(self, key: Any) -> Any:
         """
         Push an async context onto the context stack maintained by the Resolver.
         This is necessary to enter/close the context of an object

--- a/minject/model.py
+++ b/minject/model.py
@@ -85,9 +85,7 @@ def resolve_value(registry_impl: Resolver, value: Resolvable[T]) -> T:
 
 async def aresolve_value(registry_impl: Resolver, value: Resolvable[T]) -> T:
     """
-    Resolve a Resolvable value into a concrete value from the given registry.
-    If value is an instance of Deferred, it will be resolved using the provided
-    resolver, otherwise it is already a concrete value and will be returned as is.
+    Async version of resolve_value, which calls aresolve on Deferred instances.
     """
     if isinstance(value, Deferred):
         return await value.aresolve(registry_impl)

--- a/minject/model.py
+++ b/minject/model.py
@@ -37,11 +37,16 @@ class Resolver(abc.ABC):
     async def aresolve(self, key: "RegistryKey[T]") -> T:
         ...
 
+    @abc.abstractmethod
+    async def push_async_context(self, key: Any) -> Any:
+        ...
+
     @property
     @abc.abstractmethod
     def config(self) -> RegistryConfigWrapper:
         ...
 
+    
 
 MockingFunction: TypeAlias = Callable[[Arg], Any]
 

--- a/minject/model.py
+++ b/minject/model.py
@@ -34,22 +34,20 @@ class Resolver(abc.ABC):
     def resolve(self, key: "RegistryKey[T]") -> T:
         ...
 
-    @abc.abstractmethod
     async def _aresolve(self, key: "RegistryKey[T]") -> T:
         """
         Resolve a key into an instance of that key. The key must be marked
         with the @async_context decorator.
         """
-        ...
+        raise NotImplementedError("Please implement _aresolve.")
 
-    @abc.abstractmethod
     async def _push_async_context(self, key: Any) -> Any:
         """
         Push an async context onto the context stack maintained by the Resolver.
         This is necessary to enter/close the context of an object
         marked with @async_context.
         """
-        ...
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod

--- a/minject/model.py
+++ b/minject/model.py
@@ -46,7 +46,8 @@ class Resolver(abc.ABC):
     async def push_async_context(self, key: Any) -> Any:
         """
         Push an async context onto the context stack maintained by the Resolver.
-        This is necessary when resolving an object marked with @async_context.
+        This is necessary to enter/close the context of an object
+        marked with @async_context.
         """
         ...
 

--- a/minject/model.py
+++ b/minject/model.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 RegistryKey: TypeAlias = "Union[str, Type[T_co], RegistryMetadata[T_co]]"
 
+
 class Resolver(abc.ABC):
     """
     Interface capable of resolving keys and deferred values into instances.
@@ -46,7 +47,6 @@ class Resolver(abc.ABC):
     def config(self) -> RegistryConfigWrapper:
         ...
 
-    
 
 MockingFunction: TypeAlias = Callable[[Arg], Any]
 
@@ -81,6 +81,7 @@ def resolve_value(registry_impl: Resolver, value: Resolvable[T]) -> T:
         return value.resolve(registry_impl)
     else:
         return value
+
 
 async def aresolve_value(registry_impl: Resolver, value: Resolvable[T]) -> T:
     """

--- a/minject/model.py
+++ b/minject/model.py
@@ -36,10 +36,18 @@ class Resolver(abc.ABC):
 
     @abc.abstractmethod
     async def aresolve(self, key: "RegistryKey[T]") -> T:
+        """
+        Resolve a key into an instance of that key. The key must be marked
+        with the @async_context decorator.
+        """
         ...
 
     @abc.abstractmethod
     async def push_async_context(self, key: Any) -> Any:
+        """
+        Push an async context onto the context stack maintained by the Resolver.
+        This is necessary when resolving an object marked with @async_context.
+        """
         ...
 
     @property
@@ -62,6 +70,11 @@ class Deferred(abc.ABC, Generic[T_co]):
 
     @abc.abstractmethod
     async def aresolve(self, registry_impl: Resolver) -> T_co:
+        """
+        Resolve a deferred object into an instance of the object. The object,
+        may or may not be asynchronous. If the object is asynchronous (marked with @async_context),
+        resolve the object asynchronously. Otherwise, resolve synchronously.
+        """
         ...
 
 

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -370,8 +370,9 @@ class Registry(Resolver):
 
         # TODO: the reason this is split into aget and _aget is that
         # the aresolve method of Deferred objects is never called on
-        # the top level objec. This means that we must enter the context of the top
-        # level object from
+        # the top level object itself. This means that we must enter
+        # the context of the top level object from the call to aget if it
+        # has not already been entered
         enter_context = True
         meta = _get_meta_from_key(key)
         if meta in self._by_meta:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -102,13 +102,13 @@ class Registry(Resolver):
     def resolve(self, key: "RegistryKey[T]") -> T:
         return self[key]
 
-    async def aresolve(self, key: "RegistryKey[T]") -> T:
+    async def _aresolve(self, key: "RegistryKey[T]") -> T:
         result = await self._aget(key)
         if result is None:
             raise KeyError(key, "could not be resolved")
         return result
 
-    async def push_async_context(self, key: Any) -> Any:
+    async def _push_async_context(self, key: Any) -> Any:
         result = await self._async_context_stack.enter_async_context(key)
         if result is not key:
             raise ValueError(
@@ -125,7 +125,10 @@ class Registry(Resolver):
     def _resolve(self, value: Resolvable[T]) -> T:
         return resolve_value(self, value)
 
-    async def _aresolve(self, value: Resolvable[T]) -> T:
+    async def _aresolve_resolvable(self, value: Resolvable[T]) -> T:
+        """
+        Async version of _resolve.
+        """
         return await aresolve_value(self, value)
 
     @_synchronized
@@ -387,7 +390,7 @@ class Registry(Resolver):
         # requires that the top level context of key be entered, and contexts are entered
         # in a RegistryReference's aresolve method
         reference = _RegistryReference(key)
-        return await self._aresolve(reference)
+        return await self._aresolve_resolvable(reference)
 
     async def __aenter__(self) -> "Registry":
         """

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -1,5 +1,4 @@
 """The Registry itself is a runtime collection of initialized classes."""
-import asyncio
 import functools
 import logging
 from contextlib import AsyncExitStack
@@ -9,6 +8,7 @@ from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, TypeV
 
 from typing_extensions import Concatenate, ParamSpec
 
+from minject.asyncio_extensions import to_thread
 from minject.inject import _is_key_async, _RegistryReference, reference
 
 from .config import RegistryConfigWrapper, RegistryInitConfig
@@ -395,7 +395,7 @@ class Registry(Resolver):
         self._async_entered = False
         # close all objects in the registry
         await self._async_context_stack.aclose()
-        await asyncio.to_thread(self.close)
+        await to_thread(self.close)
 
     def __getitem__(self, key: "RegistryKey[T]") -> T:
         """Get an object from the registry by a key.

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -207,7 +207,7 @@ class Registry(Resolver):
 
     async def _aregister_by_metadata(self, meta: RegistryMetadata[T]) -> RegistryWrapper[T]:
         """
-        async version of _register_by_metadata. Calls _aiint_object instead of _init_object
+        async version of _register_by_metadata. Calls _ainit_object instead of _init_object.
         """
         LOG.debug("registering %s", meta)
 
@@ -338,12 +338,12 @@ class Registry(Resolver):
             raise AssertionError("cannot use aget outside of async context")
 
         meta = _get_meta_from_key(key)
-        maybe_class = self._get_if_already_in_registry(key, meta)
-        if maybe_class is not None:
-            return maybe_class
+        maybe_initialized_obj = self._get_if_already_in_registry(key, meta)
+        if maybe_initialized_obj is not None:
+            return maybe_initialized_obj
 
-        by_meta = await self._aget_by_metadata(meta)
-        return _unwrap(by_meta)
+        initialized_obj = await self._aget_by_metadata(meta)
+        return _unwrap(initialized_obj)
 
     def _get_if_already_in_registry(
         self, key: "RegistryKey[T]", meta: "RegistryMetadata[T]"

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -18,6 +18,12 @@ T = TypeVar("T")
 R = TypeVar("R")
 P = ParamSpec("P")
 
+class RegistryAPIError(Exception):
+    """
+    Error representing misuse of the Registry API.
+    Do not catch this error in your code.
+    """
+    ...
 
 class _AutoOrNone:
     def __nonzero__(self):
@@ -270,6 +276,9 @@ class Registry(Resolver):
                 return _unwrap(obj_list[0])
 
         return _unwrap(self._get_by_metadata(meta, default))
+
+    async def aget(self, key: "RegistryKey[T]", default: Optional[Union[T, _AutoOrNone]] = None) -> T:
+        raise NotImplementedError("async get not implemented")
 
     async def __aenter__(self) -> "Registry":
         return self

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -335,13 +335,10 @@ class Registry(Resolver):
         Resolve objects marked with the @async_context decorator.
         """
         if not _is_key_async(key):
-            raise AssertionError("cannot use aget outside of async context")
+            raise AssertionError("key must be async to use aget")
 
         if not self._async_entered:
             raise AssertionError("cannot use aget outside of async context")
-
-        if isinstance(key, str):
-            raise AssertionError("cannot use aget with string keys. Use get instead.")
 
         meta = _get_meta_from_key(key)
         maybe_class = self._get_if_already_in_registry(key, meta)

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -360,10 +360,12 @@ class Registry(Resolver):
         if not isinstance(key, type):
             return None
 
-        # If the class has no metadata, but a parent has been registered in registry,
-        # return the registered parent. If the class has metadata, we should not
-        # check parents, we must use the metadata attached to the class to
-        # construct the object.
+        # If the class (key) has no metadata, but an object exists in the registry
+        # that implements an interface the class implements, return the object
+        # in the registry. If the class has metadata, we should not
+        # check the registry for objects that implement interfaces implemented by
+        # the class, as we must use the metadata attached to the class to construct
+        # the object.
         meta_no_bases = _get_meta(key, include_bases=False)
         obj_list = self._by_iface.get(key)
         if meta_no_bases is None and obj_list:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -244,7 +244,7 @@ class Registry(Resolver):
 
             # after creating an object, enter the objects context
             # if it is marked with the @async_context decorator.
-            if meta.is_async_context():
+            if meta.is_async_context:
                 await self._push_async_context(obj)
 
             success = True

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -102,7 +102,10 @@ class Registry(Resolver):
         return self[key]
 
     async def aresolve(self, key: "RegistryKey[T]") -> T:
-        return await self._aget(key)
+        result = await self._aget(key)
+        if result is None:
+            raise KeyError(key, "could not be resolved")
+        return result
 
     async def push_async_context(self, key: Any) -> Any:
         result = await self._async_context_stack.enter_async_context(key)
@@ -364,7 +367,7 @@ class Registry(Resolver):
 
     async def aget(
         self, key: "RegistryKey[T]", default: Optional[Union[T, _AutoOrNone]] = None
-    ) -> T:
+    ) -> Optional[T]:
         """
         Async API for getting objects
         """

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -337,7 +337,7 @@ class Registry(Resolver):
 
     async def _aget(
         self, key: "RegistryKey[T]", default: Optional[Union[T, _AutoOrNone]] = None
-    ) -> T:
+    ) -> Optional[T]:
         # TODO: do this better
         if default is None:
             default = AUTO_OR_NONE
@@ -358,6 +358,9 @@ class Registry(Resolver):
             obj_list = self._by_iface.get(key)
             if obj_list:
                 return obj_list[0].obj
+
+        by_meta = await self._aget_by_metadata(meta, default)
+        return _unwrap(by_meta)
 
     async def aget(
         self, key: "RegistryKey[T]", default: Optional[Union[T, _AutoOrNone]] = None

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -1,4 +1,5 @@
 """The Registry itself is a runtime collection of initialized classes."""
+import asyncio
 import functools
 import logging
 from contextlib import AsyncExitStack
@@ -404,7 +405,7 @@ class Registry(Resolver):
         self._async_can_proceed = False
         # close all objects in the registry
         await self._async_context_stack.aclose()
-        self.close()
+        await asyncio.to_thread(self.close)
 
     def __getitem__(self, key: "RegistryKey[T]") -> T:
         """Get an object from the registry by a key.

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -369,11 +369,16 @@ class Registry(Resolver):
             raise RegistryAPIError("cannot use aget outside of async context")
 
         # TODO: the reason this is split into aget and _aget is that
-        # the aresolve method of Defererd objects is never called on
+        # the aresolve method of Deferred objects is never called on
         # the top level objec. This means that we must enter the context of the top
         # level object from
+        enter_context = True
+        meta = _get_meta_from_key(key)
+        if meta in self._by_meta:
+            enter_context = False
         value = await self._aget(key, default)
-        await self.push_async_context(value)
+        if enter_context:
+            await self.push_async_context(value)
         return value
 
     async def __aenter__(self) -> "Registry":

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -351,18 +351,21 @@ class Registry(Resolver):
         # retrieve the class metdata, and the metadata of class
         # without inherited metadata
         meta = _get_meta_from_key(key)
-        meta_no_bases = _get_meta(key, include_bases=False)
 
         # if the class has already been registered, return it
         if meta in self._by_meta:
             return _unwrap(self._by_meta[meta])
 
-        # if the class has no metadata, but a parent has been registered in registry,
-        # return the registered parent.
-        if isinstance(key, type) and meta_no_bases is None:
-            obj_list = self._by_iface.get(key)
-            if obj_list:
-                return _unwrap(obj_list[0])
+        # If the class has no metadata, but a parent has been registered in registry,
+        # return the registered parent. If the class has metadata, we should not
+        # check parents, we must use the metadata attached to the class to
+        # construct the object.
+        if isinstance(key, type):
+            meta_no_bases = _get_meta(key, include_bases=False)
+            if meta_no_bases is None:
+                obj_list = self._by_iface.get(key)
+                if obj_list:
+                    return _unwrap(obj_list[0])
 
         # nothing has been registered for this metadata yet
         return None

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -360,12 +360,14 @@ class Registry(Resolver):
         if not isinstance(key, type):
             return None
 
-        # If the class (key) has no metadata, but an object exists in the registry
-        # that implements an interface the class implements, return the object
-        # in the registry. If the class has metadata, we should not
-        # check the registry for objects that implement interfaces implemented by
-        # the class, as we must use the metadata attached to the class to construct
-        # the object.
+        # If the class (key) has no metadata, but an object exists in the
+        # registry that is a concrete subtype of the class, return that
+        # object. If the class has metadata, we must use the metadata to
+        # construct the class, and we should not check the registry for
+        # concrete subtypes. A user must specify metadata for a class itself
+        # in order to force the registry to use that metadata to construct the
+        # class, inherited metadata alone does not prevent the registry
+        # from returning a concrete subtype of the class.
         meta_no_bases = _get_meta(key, include_bases=False)
         obj_list = self._by_iface.get(key)
         if meta_no_bases is None and obj_list:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -125,12 +125,6 @@ class Registry(Resolver):
     def _resolve(self, value: Resolvable[T]) -> T:
         return resolve_value(self, value)
 
-    async def _aresolve_resolvable(self, value: Resolvable[T]) -> T:
-        """
-        Async version of _resolve.
-        """
-        return await aresolve_value(self, value)
-
     @_synchronized
     def close(self) -> None:
         """Close all objects contained in the registry."""

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -321,6 +321,11 @@ class Registry(Resolver):
         Returns:
             The requested object or default if not found.
         """
+        if _is_key_async(key):
+            raise RegistryAPIError(
+                "cannot use synchronous get on async object (object marked with @async_context)"
+            )
+
         if key == object:
             return None  # NEVER auto-init plain object
 
@@ -417,11 +422,6 @@ class Registry(Resolver):
         Raises:
             KeyError: if the object is not registered and cannot be generated.
         """
-        if _is_key_async(key):
-            raise RegistryAPIError(
-                "cannot use synchronous get on async object (object marked with @async_context)"
-            )
-
         obj = self.get(key, default=AUTO_OR_NONE)
         if obj is None or obj is AUTO_OR_NONE:
             raise KeyError(key)

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -22,15 +22,6 @@ R = TypeVar("R")
 P = ParamSpec("P")
 
 
-class RegistryAPIError(Exception):
-    """
-    Error representing misuse of the Registry API.
-    Do not catch this error.
-    """
-
-    ...
-
-
 class _AutoOrNone:
     def __nonzero__(self):
         return False
@@ -322,7 +313,7 @@ class Registry(Resolver):
             The requested object or default if not found.
         """
         if _is_key_async(key):
-            raise RegistryAPIError(
+            raise AssertionError(
                 "cannot use synchronous get on async object (object marked with @async_context)"
             )
 
@@ -344,13 +335,13 @@ class Registry(Resolver):
         Resolve objects marked with the @async_context decorator.
         """
         if not _is_key_async(key):
-            raise RegistryAPIError("cannot use aget outside of async context")
+            raise AssertionError("cannot use aget outside of async context")
 
         if not self._async_entered:
-            raise RegistryAPIError("cannot use aget outside of async context")
+            raise AssertionError("cannot use aget outside of async context")
 
         if isinstance(key, str):
-            raise RegistryAPIError("cannot use aget with string keys. Use get instead.")
+            raise AssertionError("cannot use aget with string keys. Use get instead.")
 
         meta = _get_meta_from_key(key)
         maybe_class = self._get_if_already_in_registry(key, meta)
@@ -392,7 +383,7 @@ class Registry(Resolver):
         Mark a registry instance as ready for resolving async objects.
         """
         if self._async_entered:
-            raise RegistryAPIError(
+            raise AssertionError(
                 "Attempting to enter registry context while already in context. This should not happen."
             )
         self._async_entered = True
@@ -404,7 +395,7 @@ class Registry(Resolver):
         and then closes the registry itself with regisry.close().
         """
         if not self._async_entered:
-            raise RegistryAPIError(
+            raise AssertionError(
                 "Attempting to exit registry context while not in context. This should not happen."
             )
         self._async_entered = False

--- a/minject/types.py
+++ b/minject/types.py
@@ -29,6 +29,7 @@ class _AsyncContext(Protocol):
     """
     Protocol for any object that can be used as an async context manager.
     """
+
     async def __aenter__(self: Self) -> Self:
         ...
 

--- a/minject/types.py
+++ b/minject/types.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, TypeVar
+from types import TracebackType
+from typing import Any, Dict, Type, TypeVar
 
-from typing_extensions import Protocol, runtime_checkable
+from typing_extensions import Protocol, Self, runtime_checkable
 
 Arg = Any
 Kwargs = Dict[str, Arg]
@@ -21,4 +22,14 @@ class _MinimalMappingProtocol(Protocol[K_contra, V_co]):
         ...
 
     def __contains__(self, key: K_contra) -> bool:
+        ...
+
+
+class _AsyncContext(Protocol):
+    async def __aenter__(self: Self) -> Self:
+        ...
+
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType
+    ) -> None:
         ...

--- a/minject/types.py
+++ b/minject/types.py
@@ -27,7 +27,9 @@ class _MinimalMappingProtocol(Protocol[K_contra, V_co]):
 
 class _AsyncContext(Protocol):
     """
-    Protocol for any object that can be used as an async context manager.
+    Protocol for an object that can be marked with the @async_context
+    decorator. This is any async context manager that return Self from
+    it's __aenter__ method.
     """
 
     async def __aenter__(self: Self) -> Self:

--- a/minject/types.py
+++ b/minject/types.py
@@ -26,6 +26,9 @@ class _MinimalMappingProtocol(Protocol[K_contra, V_co]):
 
 
 class _AsyncContext(Protocol):
+    """
+    Protocol for any object that can be used as an async context manager.
+    """
     async def __aenter__(self: Self) -> Self:
         ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
+    'pytest-asyncio',
     "typing",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     'pytest',
     'pytest-mock',
     'pytest-randomly',
+    'pytest-asyncio',
     'pytest-rerunfailures',
     'pytest-xdist[psutil]',
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode=auto

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -333,3 +333,15 @@ async def test_exit_logic_failure(registry: Registry) -> None:
     assert my_cls.entered == False
     assert my_cls.sync_close_dep.closed == True
 
+
+async def test_async_contains(registry: Registry) -> None:
+    async with registry as r:
+        assert (MyAsyncApi in r) is False
+        assert (MyDependencyAsync in r) is False
+        assert (MyDependencyNotSpecifiedAsync in r) is False
+
+        _ = await r.aget(MyAsyncApi)
+
+        assert (MyAsyncApi in r) is True
+        assert (MyDependencyAsync in r) is True
+        assert (MyDependencyNotSpecifiedAsync in r) is True

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -60,7 +60,16 @@ class MyAsyncApi:
         self.in_context = False
         pass
 
-async def test_async_registry(registry : Registry) -> None:
+async def test_async_registry_simple(registry : Registry) -> None:
+    async with registry as r:
+        my_api = await r.aget(MyDependencyAsync)
+        assert my_api.in_context == True
+
+    assert my_api.in_context == False
+
+
+
+async def test_async_registry_recursive(registry : Registry) -> None:
     async with registry as r:
         my_api = await r.aget(MyAsyncApi)
         assert my_api.text == TEXT

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,51 +1,61 @@
-
-
-from typing import Type
-import pytest
-from minject.registry import Registry, RegistryAPIError
-from minject.inject import bind, reference, async_context
-
 from types import TracebackType
+from typing import Type
+
+import pytest
+
+from minject.inject import async_context, bind, reference
+from minject.registry import Registry, RegistryAPIError
 
 TEXT = "we love tests"
+
 
 @pytest.fixture
 def registry() -> Registry:
     return Registry()
 
+
 class MyDependencyNotSpecifiedAsync:
     def __init__(self) -> None:
         self.in_context = False
-    
+
     async def __aenter__(self) -> "MyDependencyNotSpecifiedAsync":
         self.in_context = True
         return self
-    
-    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType
+    ) -> None:
         del exc_type, exc_value, traceback
         self.in_context = False
-        pass
+
 
 @async_context
 class MyDependencyAsync:
     def __init__(self) -> None:
         self.in_context = False
-    
+
     async def __aenter__(self) -> "MyDependencyAsync":
         self.in_context = True
         return self
-    
-    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType
+    ) -> None:
         del exc_type, exc_value, traceback
         self.in_context = False
-        pass
+
 
 @async_context
 @bind(text=TEXT)
 @bind(dep_async=reference(MyDependencyAsync))
 @bind(dep_not_specified=reference(MyDependencyNotSpecifiedAsync))
 class MyAsyncApi:
-    def __init__(self, text : str, dep_async : MyDependencyAsync, dep_not_specified : MyDependencyNotSpecifiedAsync) -> None:
+    def __init__(
+        self,
+        text: str,
+        dep_async: MyDependencyAsync,
+        dep_not_specified: MyDependencyNotSpecifiedAsync,
+    ) -> None:
         self.text = text
         self.in_context = False
         self.dep_async = dep_async
@@ -54,13 +64,15 @@ class MyAsyncApi:
     async def __aenter__(self) -> "MyAsyncApi":
         self.in_context = True
         return self
-    
-    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType
+    ) -> None:
         del exc_type, exc_value, traceback
         self.in_context = False
-        pass
 
-async def test_async_registry_simple(registry : Registry) -> None:
+
+async def test_async_registry_simple(registry: Registry) -> None:
     async with registry as r:
         my_api = await r.aget(MyDependencyAsync)
         assert my_api.in_context == True
@@ -68,8 +80,7 @@ async def test_async_registry_simple(registry : Registry) -> None:
     assert my_api.in_context == False
 
 
-
-async def test_async_registry_recursive(registry : Registry) -> None:
+async def test_async_registry_recursive(registry: Registry) -> None:
     async with registry as r:
         my_api = await r.aget(MyAsyncApi)
         assert my_api.text == TEXT
@@ -81,14 +92,16 @@ async def test_async_registry_recursive(registry : Registry) -> None:
     assert my_api.dep_async.in_context == False
     assert my_api.dep_not_specified.in_context == False
 
-async def test_multiple_instantiation(registry : Registry) -> None:
+
+async def test_multiple_instantiation(registry: Registry) -> None:
     async with registry as r:
         my_api = await r.aget(MyAsyncApi)
         my_api_2 = await r.aget(MyAsyncApi)
         my_api_3 = await r.aget(MyAsyncApi)
         assert my_api is my_api_2 is my_api_3
 
-async def test_async_context_outside_context_manager(registry : Registry) -> None:
+
+async def test_async_context_outside_context_manager(registry: Registry) -> None:
     with pytest.raises(RegistryAPIError):
         # attempting to instantiate a class
         # marked with @async_context without
@@ -96,8 +109,8 @@ async def test_async_context_outside_context_manager(registry : Registry) -> Non
         # raise an error
         _ = await registry.aget(MyAsyncApi)
 
-async def test_try_instantiate_async_class_with_sync_api(registry : Registry) -> None:
 
+async def test_try_instantiate_async_class_with_sync_api(registry: Registry) -> None:
     with pytest.raises(RegistryAPIError):
         # attempting to instantiate a class
         # marked with @async_context using sync API

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -177,6 +177,16 @@ async def test_multiple_instantiation_top_level(registry: Registry) -> None:
     assert my_counter.exited_context_counter == 1
 
 
+async def test_multiple_instantiation_mixed(registry: Registry) -> None:
+    my_counter: MyAsyncAPIContextCounter
+    async with registry as r:
+        my_counter = await r.aget(MyAsyncAPIContextCounter)
+        assert my_counter.entered_context_counter == 1
+        await r.aget(MyAsyncApi)
+        assert my_counter.entered_context_counter == 1
+    assert my_counter.exited_context_counter == 1
+
+
 async def test_async_context_outside_context_manager(registry: Registry) -> None:
     with pytest.raises(RegistryAPIError):
         # attempting to instantiate a class

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -215,3 +215,10 @@ async def test_config_in_async(registry: Registry) -> None:
         r = await r.aget(MyAsyncApiWithConfig)
         assert r.nested == "c"
         assert r.flat == 2
+
+
+async def test_entering_already_entered_registry_throws(registry: Registry) -> None:
+    async with registry as r:
+        with pytest.raises(RegistryAPIError):
+            async with r:
+                pass

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,76 @@
+
+
+from typing import Type
+import pytest
+from minject.registry import Registry
+from minject.inject import bind, reference, async_context
+
+from types import TracebackType
+
+TEXT = "we love tests"
+
+@pytest.fixture
+def registry() -> Registry:
+    return Registry()
+
+class MyDependencyNotSpecifiedAsync:
+    def __init__(self) -> None:
+        self.in_context = False
+    
+    async def __aenter__(self) -> "MyDependencyNotSpecifiedAsync":
+        self.in_context = True
+        return self
+    
+    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+        del exc_type, exc_value, traceback
+        self.in_context = False
+        pass
+
+@async_context
+class MyDependencyAsync:
+    def __init__(self) -> None:
+        self.in_context = False
+    
+    async def __aenter__(self) -> "MyDependencyAsync":
+        self.in_context = True
+        return self
+    
+    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+        del exc_type, exc_value, traceback
+        self.in_context = False
+        pass
+
+@async_context
+@bind(text=TEXT)
+@bind(dep_async=reference(MyDependencyAsync))
+@bind(dep_not_specified=reference(MyDependencyNotSpecifiedAsync))
+class MyApi:
+    def __init__(self, text : str, dep_async : MyDependencyAsync, dep_not_specified : MyDependencyNotSpecifiedAsync) -> None:
+        self.text = text
+        self.in_context = False
+        self.dep_async = dep_async
+        self.dep_not_specified = dep_not_specified
+
+    async def __aenter__(self) -> "MyApi":
+        self.in_context = True
+        return self
+    
+    async def __aexit__(self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
+        del exc_type, exc_value, traceback
+        self.in_context = False
+        pass
+
+async def test_async_registry(registry : Registry) -> None:
+    async with registry as r:
+        my_api = r[MyApi]
+        assert my_api.text == TEXT
+        assert my_api.in_context == True
+        assert my_api.dep_async.in_context == True
+        assert my_api.dep_not_specified.in_context == False
+
+    assert my_api.in_context == False
+    assert my_api.dep_async.in_context == False
+    assert my_api.dep_not_specified.in_context == False
+
+
+

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,7 +4,7 @@ from typing import Dict, Type
 import pytest
 
 from minject.inject import async_context, bind, config, define, nested_config, reference
-from minject.registry import Registry, RegistryAPIError
+from minject.registry import Registry
 
 TEXT = "we love tests"
 
@@ -197,7 +197,7 @@ async def test_multiple_instantiation_mixed(registry: Registry) -> None:
 
 
 async def test_async_context_outside_context_manager(registry: Registry) -> None:
-    with pytest.raises(RegistryAPIError):
+    with pytest.raises(AssertionError):
         # attempting to instantiate a class
         # marked with @async_context without
         # being in an async context should
@@ -206,13 +206,13 @@ async def test_async_context_outside_context_manager(registry: Registry) -> None
 
 
 async def test_try_instantiate_async_class_with_sync_api(registry: Registry) -> None:
-    with pytest.raises(RegistryAPIError):
+    with pytest.raises(AssertionError):
         # attempting to instantiate a class
         # marked with @async_context using sync API
         # should raise an error
         _ = registry[MyDependencyAsync]
 
-    with pytest.raises(RegistryAPIError):
+    with pytest.raises(AssertionError):
         # still throws an error even when registry context
         # has been entered
         async with registry as r:
@@ -238,7 +238,7 @@ async def test_config_in_async(registry: Registry) -> None:
 
 async def test_entering_already_entered_registry_throws(registry: Registry) -> None:
     async with registry as r:
-        with pytest.raises(RegistryAPIError):
+        with pytest.raises(AssertionError):
             async with r:
                 pass
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -81,6 +81,13 @@ async def test_async_registry_recursive(registry : Registry) -> None:
     assert my_api.dep_async.in_context == False
     assert my_api.dep_not_specified.in_context == False
 
+async def test_multiple_instantiation(registry : Registry) -> None:
+    async with registry as r:
+        my_api = await r.aget(MyAsyncApi)
+        my_api_2 = await r.aget(MyAsyncApi)
+        my_api_3 = await r.aget(MyAsyncApi)
+        assert my_api is my_api_2 is my_api_3
+
 async def test_async_context_outside_context_manager(registry : Registry) -> None:
     with pytest.raises(RegistryAPIError):
         # attempting to instantiate a class
@@ -96,3 +103,9 @@ async def test_try_instantiate_async_class_with_sync_api(registry : Registry) ->
         # marked with @async_context using sync API
         # should raise an error
         _ = registry[MyDependencyAsync]
+
+    with pytest.raises(RegistryAPIError):
+        # still throws an error even when registry context
+        # has been entered
+        async with registry as r:
+            _ = r[MyAsyncApi]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,8 +5,6 @@ from functools import lru_cache
 from random import shuffle
 from typing import Sequence
 
-import pytest
-
 import tests.test_registry_helpers as helpers
 from minject.inject import (
     _RegistryConfig,
@@ -458,7 +456,6 @@ class RegistryTestCase(unittest.TestCase):
         self.assertEqual(n_objects, len(self.registry))
         self.assertEqual(n_objects, len(self.registry._by_name))
 
-    @pytest.mark.skip(reason="This test is flaky")
     def test_concurrent_lazy_init(self) -> None:
         """
         Test lazy initialization of singletons in a concurrent environment always returns the same object

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,6 +5,8 @@ from functools import lru_cache
 from random import shuffle
 from typing import Sequence
 
+import pytest
+
 import tests.test_registry_helpers as helpers
 from minject.inject import (
     _RegistryConfig,
@@ -456,6 +458,7 @@ class RegistryTestCase(unittest.TestCase):
         self.assertEqual(n_objects, len(self.registry))
         self.assertEqual(n_objects, len(self.registry._by_name))
 
+    @pytest.mark.skip(reason="This test is flaky")
     def test_concurrent_lazy_init(self) -> None:
         """
         Test lazy initialization of singletons in a concurrent environment always returns the same object


### PR DESCRIPTION
Fixes #9.

Adds Async Support to Minject with the following API:

```python
@async_context
@inject.bind(text = "hi")
class MyClass:
    def __init__(self, text : str):
        self.text = text
        self.in_context = False

    async def __aenter__(self : Self) -> Self:
        self.in_context = True
        return self 
    
    async def __aexit__(self : Self, exc_type : Type[BaseException], exc_value : BaseException, traceback : TracebackType) -> None:
        self.in_context = False

async def main():
    my_class : MyClass
    async with Registry() as r:
        my_class = await r.aget(MyClass)
        assert my_class.text == "hi"
        assert my_class.in_context == True
    
    assert my_class.in_context == False
```

This PR only adds implementation + tests. Once we agree on implementation I can add docs.

## Verification Steps

- [x] Doc Strings
- [ ] Created Issue to Document feature (will do this once we this PR is merged)