### PR TITLE
Reduce indirection by removing Registry._resolve

### DIFF
--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -14,7 +14,7 @@ from typing import (
     TypeVar,
 )
 
-from .model import DeferredAny, RegistryKey
+from .model import DeferredAny, RegistryKey, resolve_value
 from .types import Kwargs
 
 if TYPE_CHECKING:
@@ -155,7 +155,7 @@ class RegistryMetadata(Generic[T_co]):
     def _init_object(self, obj: T_co, registry_impl: "Registry") -> None:  # type: ignore[misc]
         init_kwargs = {}
         for name_, value in self._bindings.items():
-            init_kwargs[name_] = registry_impl._resolve(value)
+            init_kwargs[name_] = resolve_value(registry_impl, value)
 
         self._cls.__init__(obj, **init_kwargs)
 

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -86,9 +86,6 @@ class Registry(Resolver):
     def resolve(self, key: "RegistryKey[T]") -> T:
         return self[key]
 
-    def _resolve(self, value: Resolvable[T]) -> T:
-        return resolve_value(self, value)
-
     @_synchronized
     def close(self) -> None:
         """Close all objects contained in the registry."""


### PR DESCRIPTION
Registry._resolve() was a thin wrapper around model.resolve_value as a method rather than a free function. It was undocumented and only called in one place, and that place already imported identifiers from the model module.

This simplifies the code by having the caller use resolve_value directly.