### PR TITLE
Update Version to Match PyPI Release Version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 # Changelog
 
-## v1.1.0-beta.1
+## v1.1.0
 
 Add support for async Python. This version introduces the following methods and decorators:
 

--- a/minject/__init__.py
+++ b/minject/__init__.py
@@ -44,7 +44,7 @@ registry['something_i_need'] = make_something()
 something = registry['something_i_need']
 """
 
-__version__ = "1.1.0-beta.1"
+__version__ = "1.1.0"
 
 from . import inject
 from .inject_attrs import inject_define as define, inject_field as field


### PR DESCRIPTION
Changes version from `1.1.0-beta1` to `1.1.0`. This is because PyPI published the package as `1.1.0` due to it truncating the `-beta.1` suffix as it did not conform to [PEP-440](https://peps.python.org/pep-0440/).

We have decided to just release the package as `1.1.0` due to PyPI's strict rules around removing packages. If we end up needing to make a breaking change to the async API in the next week or so, we will consider removing `1.1.0`.