### PR TITLE
Update `duolingo` pre-commit hook to 1.8.0 (TOOLS-581)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,6 @@ repos:
         language: system
         files: ^minject/.*
   - repo: https://github.com/duolingo/pre-commit-hooks.git
-    rev: 1.7.3
+    rev: 1.8.0
     hooks:
       - id: duolingo

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -55,8 +55,7 @@ RAISE_KEY_ERROR = _RaiseKeyError()
 
 # Overload for when we _cannot_ infer what `T` will be from a call to bind
 @overload
-def bind(_close: None = None, **bindings: DeferredAny) -> Callable[[Type[T]], Type[T]]:
-    ...
+def bind(_close: None = None, **bindings: DeferredAny) -> Callable[[Type[T]], Type[T]]: ...
 
 
 # Overload for when we _can_ infer what `T` will be from a call to bind.
@@ -64,8 +63,7 @@ def bind(_close: None = None, **bindings: DeferredAny) -> Callable[[Type[T]], Ty
 def bind(
     _close: Optional[Callable[[T], None]] = None,
     **bindings: DeferredAny,
-) -> Callable[[Type[T]], Type[T]]:
-    ...
+) -> Callable[[Type[T]], Type[T]]: ...
 
 
 def bind(
@@ -198,18 +196,15 @@ class _RegistryReference(Deferred[T_co]):
 
 
 @overload
-def reference(key: RegistryMetadata[T]) -> _RegistryReference[T]:
-    ...
+def reference(key: RegistryMetadata[T]) -> _RegistryReference[T]: ...
 
 
 @overload
-def reference(key: str) -> _RegistryReference:
-    ...
+def reference(key: str) -> _RegistryReference: ...
 
 
 @overload
-def reference(key: Type[T], **bindings: DeferredAny) -> _RegistryReference[T]:
-    ...
+def reference(key: Type[T], **bindings: DeferredAny) -> _RegistryReference[T]: ...
 
 
 def reference(key, **bindings):

--- a/minject/inject_attrs.py
+++ b/minject/inject_attrs.py
@@ -92,7 +92,7 @@ class _BindingKey:
     class_lineno: int  # The line containing the "class" keyword.
 
 
-_key_binding_mapping: DefaultDict[_BindingKey, dict] = defaultdict(lambda: {})
+_key_binding_mapping: DefaultDict[_BindingKey, dict] = defaultdict(dict)
 
 
 def inject_field(binding=_T, **attr_field_kwargs) -> Any:

--- a/minject/model.py
+++ b/minject/model.py
@@ -31,8 +31,7 @@ class Resolver(abc.ABC):
     """
 
     @abc.abstractmethod
-    def resolve(self, key: "RegistryKey[T]") -> T:
-        ...
+    def resolve(self, key: "RegistryKey[T]") -> T: ...
 
     async def _aresolve(self, key: "RegistryKey[T]") -> T:
         """
@@ -51,8 +50,7 @@ class Resolver(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def config(self) -> RegistryConfigWrapper:
-        ...
+    def config(self) -> RegistryConfigWrapper: ...
 
 
 MockingFunction: TypeAlias = Callable[[Arg], Any]
@@ -64,8 +62,7 @@ class Deferred(abc.ABC, Generic[T_co]):
     """
 
     @abc.abstractmethod
-    def resolve(self, registry_impl: Resolver) -> T_co:
-        ...
+    def resolve(self, registry_impl: Resolver) -> T_co: ...
 
     @abc.abstractmethod
     async def aresolve(self, registry_impl: Resolver) -> T_co:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -1,4 +1,5 @@
 """The Registry itself is a runtime collection of initialized classes."""
+
 import functools
 import logging
 from contextlib import AsyncExitStack
@@ -57,7 +58,7 @@ class RegistryWrapper(Generic[T]):
 
 
 def _synchronized(
-    func: Callable[Concatenate["Registry", P], R]
+    func: Callable[Concatenate["Registry", P], R],
 ) -> Callable[Concatenate["Registry", P], R]:
     """Decorator to synchronize method access with a reentrant lock."""
 

--- a/minject/types.py
+++ b/minject/types.py
@@ -18,11 +18,9 @@ class _MinimalMappingProtocol(Protocol[K_contra, V_co]):
     Defines the minimum methods needed for the dict-like objects acceptable to RegistryNestedConfig.
     """
 
-    def __getitem__(self, key: K_contra) -> V_co:
-        ...
+    def __getitem__(self, key: K_contra) -> V_co: ...
 
-    def __contains__(self, key: K_contra) -> bool:
-        ...
+    def __contains__(self, key: K_contra) -> bool: ...
 
 
 class _AsyncContext(Protocol):
@@ -32,10 +30,8 @@ class _AsyncContext(Protocol):
     it's __aenter__ method.
     """
 
-    async def __aenter__(self: Self) -> Self:
-        ...
+    async def __aenter__(self: Self) -> Self: ...
 
     async def __aexit__(
         self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType
-    ) -> None:
-        ...
+    ) -> None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,59 +1,60 @@
 [project]
-name = "minject"
-description = "A small dependency injection library for Python."
-classifiers = ['Development Status :: 5 - Production/Stable']
-dynamic = ["version"]
-authors = [{ name = "Matt McHenry", email = "mmchenry@duolingo.com" }, { name = "Alek Binion", email = "alek@duolingo.com" }, { name = "Xiyan Shao", email = "xiyan@duolingo.com"}, { name = "Service Framework Team", email = "service-framework-team@duolingo.com" }]
-requires-python = ">=3.7"
-license = { file = "LICENSE" }
-
-dependencies = [
-    "attrs>=17.4",
-    "typing_extensions>=4.1",
+authors = [
+  { name = "Matt McHenry", email = "mmchenry@duolingo.com" },
+  { name = "Alek Binion", email = "alek@duolingo.com" },
+  { name = "Xiyan Shao", email = "xiyan@duolingo.com" },
+  { name = "Service Framework Team", email = "service-framework-team@duolingo.com" },
 ]
+classifiers = ['Development Status :: 5 - Production/Stable']
+description = "A small dependency injection library for Python."
+dynamic = ["version"]
+license = { file = "LICENSE" }
+name = "minject"
+requires-python = ">=3.7"
+
+dependencies = ["attrs>=17.4", "typing_extensions>=4.1"]
 
 [build-system]
-requires = ["hatchling >= 1.10.0"]
 build-backend = "hatchling.build"
+requires = ["hatchling >= 1.10.0"]
 
 [tool.hatch.version]
 path = "minject/__init__.py"
 
 [tool.hatch.envs.default]
 dependencies = [
-    # Developer dependencies. E.g. for testing, building, packaging, etc.
-    "coverage",
-    "mypy",
-    "pre-commit",
-    "pylint",
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-xdist",
-    'pytest-asyncio',
-    "typing",
+  # Developer dependencies. E.g. for testing, building, packaging, etc.
+  "coverage",
+  "mypy",
+  "pre-commit",
+  "pylint",
+  "pytest",
+  "pytest-asyncio",
+  "pytest-cov",
+  "pytest-mock",
+  "pytest-xdist",
+  'pytest-asyncio',
+  "typing",
 ]
 
 [tool.hatch.envs.hatch-test]
 dependencies = [
-    # The default hatch-test dependencies are not compatible with Python 3.7, a version we want to test against. Hence
-    # we need to specify our own dependencies here.
-    # https://github.com/pypa/hatch/blob/3adae6c0dfd5c20dfe9bf6bae19b44a696c22a43/src/hatch/env/internal/test.py
-    "coverage[toml]",
-    'coverage-enable-subprocess',
-    'pytest',
-    'pytest-asyncio',
-    'pytest-mock',
-    'pytest-randomly',
-    'pytest-asyncio',
-    'pytest-rerunfailures',
-    'pytest-xdist[psutil]',
+  # The default hatch-test dependencies are not compatible with Python 3.7, a version we want to test against. Hence
+  # we need to specify our own dependencies here.
+  # https://github.com/pypa/hatch/blob/3adae6c0dfd5c20dfe9bf6bae19b44a696c22a43/src/hatch/env/internal/test.py
+  "coverage[toml]",
+  'coverage-enable-subprocess',
+  'pytest',
+  'pytest-asyncio',
+  'pytest-mock',
+  'pytest-randomly',
+  'pytest-asyncio',
+  'pytest-rerunfailures',
+  'pytest-xdist[psutil]',
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-
 
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive minject"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -376,8 +376,7 @@ class RegistryTestCase(unittest.TestCase):
             base.closed = True
 
         @bind(_close=close)
-        class Sub(Base):
-            ...
+        class Sub(Base): ...
 
         # Registry starts on initial lookup as part of the initiation process
         instance = self.registry[Sub]
@@ -492,8 +491,7 @@ def check_registry_interface_variance_convenience_methods() -> None:
     # Test that variance is bound to the type (RegistryMetadata) and not the method.
     DefinedSub = define(_Sub)
 
-    def check_covariance(_: RegistryMetadata[_Super]) -> None:
-        ...
+    def check_covariance(_: RegistryMetadata[_Super]) -> None: ...
 
     check_covariance(DefinedSub)
 

--- a/tests/test_registry_attrs.py
+++ b/tests/test_registry_attrs.py
@@ -129,12 +129,10 @@ def test_attr_defaults() -> None:
     """
 
     @inject_define
-    class TestClassOne:
-        ...
+    class TestClassOne: ...
 
     @inject_define(define_kwargs={})
-    class TestClassTwo:
-        ...
+    class TestClassTwo: ...
 
     assert TestClassOne() != TestClassOne()
     assert TestClassTwo() == TestClassTwo()


### PR DESCRIPTION
## Description

This yearly upgrade does the following and should be pretty safe:

- Adds support for autoformatting Go, C++, TOML
- Reduces the Docker image size by 60%
- Updates Prettier/Ruff/ktfmt/etc to their latest versions
  - Most notable new feature: Kotlin trailing commas
- Updates [Splinter](https://github.com/duolingo/splinter) (if present) to respect `splinter:ignore` comments

---

<details><summary>Click here to view the <a href="https://github.com/duolingo/scratch/tree/master/art/pulldozer-duolingo">Pulldozer</a> transformation script used to create this PR</summary>

```shell
#!/usr/bin/env sh

COMMIT_MESSAGE='Update `duolingo` pre-commit hook to 1.8.0 (TOOLS-581)'

transform() {
  # Update pre-commit hook
  replace_all '(repo: https://github.com/duolingo/pre-commit-hooks\.git.+rev: ).+(\n +hooks:\n +- id: duolingo)' '\11.8.0\2' '\.pre-commit-config\.yaml$'
  duo format || true

  # Update Splinter
  duo replace '(repo: https://github.com/duolingo/splinter\.git.+rev: ).+(\n +hooks:\n +- id: splinter)' '\11.4.0\2' '\.pre-commit-config\.yaml$'
}

# duo hound '^    rev: 1\.[0-7]\.[0-4]$' '^\.pre-commit-config\.yaml$' | cut -d/ -f1 | uniq
REPOS='
duolingo/minject
duolingo/metasearch
duolingo/pulldozer
duolingo/splinter
'

DESCRIPTION='## Description

This yearly upgrade does the following and should be pretty safe:

- Adds support for autoformatting Go, C++, TOML
- Reduces the Docker image size by 60%
- Updates Prettier/Ruff/ktfmt/etc to their latest versions
  - Most notable new feature: Kotlin trailing commas
- Updates [Splinter](https://github.com/duolingo/splinter) (if present) to respect `splinter:ignore` comments'
```