### PR TITLE
Add missing dependency 'packaging'

### DIFF
--- a/.github/workflows/hatch_test.yml
+++ b/.github/workflows/hatch_test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.10", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.10", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 # Changelog
 
+## v1.1.2
+
+Add missing transitive dependency `packaging`.
+
 ## v1.1.1
 
 Fix inject_define bindings for multiple class declarations with the same class

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ## v1.1.2
 
-Add missing transitive dependency `packaging`.
+Add missing dependency `packaging`.
 
 ## v1.1.1
 

--- a/minject/__init__.py
+++ b/minject/__init__.py
@@ -44,7 +44,7 @@ registry['something_i_need'] = make_something()
 something = registry['something_i_need']
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 from . import inject
 from .inject_attrs import inject_define as define, inject_field as field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "A small dependency injection library for Python."
 dynamic = ["version"]
 license = { file = "LICENSE" }
 name = "minject"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 dependencies = ["attrs>=17.4", "packaging", "typing_extensions>=4.1"]
 
@@ -54,10 +54,10 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive minject"
 
 [[tool.hatch.envs.types.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { file = "LICENSE" }
 name = "minject"
 requires-python = ">=3.7"
 
-dependencies = ["attrs>=17.4", "typing_extensions>=4.1"]
+dependencies = ["attrs>=17.4", "packaging", "typing_extensions>=4.1"]
 
 [build-system]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Imported here: https://github.com/duolingo/minject/blob/master/minject/inject_attrs.py#L8

We must have gotten lucky before that callers were already importing this package (or maybe one of the other dependencies was pulling it in but no longer is?).