### PR TITLE
Allow `RegistryMetadata` to process bindings for unhashable objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 # Changelog
 
+## v1.4.0
+
+Allow `RegistryMetadata` to process bindings for unhashable objects. If a bound
+object is unhashable, the binding key uses the object's ID instead.
+
 ## v1.3.0
 
 Relax `RegistryInitConfig` from `Dict` to `Mapping`.

--- a/minject/__init__.py
+++ b/minject/__init__.py
@@ -44,7 +44,7 @@ registry['something_i_need'] = make_something()
 something = registry['something_i_need']
 """
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 from . import inject
 from .inject_attrs import inject_define as define, inject_field as field

--- a/tests/test_unhashable_bindings.py
+++ b/tests/test_unhashable_bindings.py
@@ -1,0 +1,44 @@
+from minject import initialize, inject
+
+
+class UnhashableDict(dict):
+    """A dict subclass that's explicitly not hashable."""
+
+    __hash__ = None  # Make this class explicitly unhashable
+
+
+def test_unhashable_binding():
+    """Test that an unhashable object can be used in a binding."""
+    unhashable_obj = UnhashableDict({"key": "value"})
+
+    @inject.bind(config=unhashable_obj)
+    class ConfigConsumer:
+        def __init__(self, config):
+            self.config = config
+
+    registry = initialize()
+    config_consumer = registry[ConfigConsumer]
+
+    # Verify that the binding worked correctly
+    assert config_consumer.config is unhashable_obj
+
+
+def test_nested_unhashable_binding():
+    """Test that an unhashable object works in a multi-level binding."""
+    unhashable_obj = UnhashableDict({"key": "value"})
+
+    @inject.bind(config=unhashable_obj)
+    class ConfigProvider:
+        def __init__(self, config):
+            self.config = config
+
+    @inject.bind(provider=inject.reference(ConfigProvider))
+    class ConfigConsumer:
+        def __init__(self, provider):
+            self.provider = provider
+
+    registry = initialize()
+    config_consumer = registry[ConfigConsumer]
+
+    # Verify the bindings worked through multiple levels
+    assert config_consumer.provider.config is unhashable_obj


### PR DESCRIPTION
This change was ported from a corresponding Duolingo-internal library (https://github.com/duolingo/python-duolingo-base/pull/662) by feeding the diff into Cursor and giving it the following prompt:

> The above is the diff of a change I made in a different fork of this project. Identify related files within this project and make the corresponding changes there. Be sure to include appropriate type annotations and and tests as needed. Within those parameters, stick as close to the provided diff as possible, without extraneous changes.
> 
> The point of this patch is to allow a user to apply an `inject.bind` decorator that binds an object that is NOT hashable, and then use the Registry to retrieve an instance of the class that uses that binding. The most important test in the diff is the one added in `test_config_in_registry.py`, so be sure to add an analogous test here.

The tests are not _exactly_ how I would have written them, but I reviewed them carefully and I think they're pretty reasonable.