### PR TITLE
Support Legacy APIs

### DIFF
--- a/minject/config.py
+++ b/minject/config.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Mapping, Optional, TypeVar
+import importlib
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, TypeVar
 
 from typing_extensions import TypedDict
 
@@ -17,8 +18,15 @@ RegistryInitConfig = Mapping[str, Any]
 class RegistryConfigWrapper:
     """Manages the configuration of the registry."""
 
-    def __init__(self):
+    def __init__(self, autostart: Callable[[], None] = lambda : None):
         self._impl = {}
+        self._autostart = autostart
+
+    def from_dict(self, config_dict: RegistryInitConfig) -> "RegistryConfigWrapper":
+        """
+        Deprecated: Support legacy minject API. Do not use this in new code.
+        """
+        self._from_dict(config_dict)
 
     def _from_dict(self, config_dict: RegistryInitConfig):
         """Configure the registry from a dictionary-like mapping.
@@ -29,6 +37,9 @@ class RegistryConfigWrapper:
             config_dict: the configuration data to apply.
         """
         self._impl = config_dict
+
+        # to support legacy behavior of auto starting registry instances
+        self._autostart()
 
     def __contains__(self, key: str):
         return key in self._impl

--- a/minject/config.py
+++ b/minject/config.py
@@ -18,9 +18,8 @@ RegistryInitConfig = Mapping[str, Any]
 class RegistryConfigWrapper:
     """Manages the configuration of the registry."""
 
-    def __init__(self, autostart: Callable[[], None] = lambda : None):
+    def __init__(self):
         self._impl = {}
-        self._autostart = autostart
 
     def from_dict(self, config_dict: RegistryInitConfig) -> "RegistryConfigWrapper":
         """
@@ -37,9 +36,6 @@ class RegistryConfigWrapper:
             config_dict: the configuration data to apply.
         """
         self._impl = config_dict
-
-        # to support legacy behavior of auto starting registry instances
-        self._autostart()
 
     def __contains__(self, key: str):
         return key in self._impl

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -79,7 +79,7 @@ class Registry(Resolver):
         self._by_meta: Dict[RegistryMetadata, RegistryWrapper] = {}
         self._by_name: Dict[str, RegistryWrapper] = {}
         self._by_iface: Dict[type, List[RegistryWrapper]] = {}
-        self._config = RegistryConfigWrapper(autostart=self._autostart)
+        self._config = RegistryConfigWrapper()
         self._lock = RLock()
         self._async_context_stack: AsyncExitStack = AsyncExitStack()
         self._async_entered = False
@@ -87,7 +87,7 @@ class Registry(Resolver):
         if config is not None:
             self._config._from_dict(config)
 
-    def _autostart(self) -> None:
+    def start(self) -> None:
         """
         Deprecated feature:
 

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -133,7 +133,9 @@ class Registry(Resolver):
 
     @_synchronized
     def close(self) -> None:
-        """Close all objects contained in the registry."""
+        """
+        Close all objects contained in the registry.
+        """
         for wrapper in list(reversed(self._objects)):
             if wrapper._meta is not None:
                 # call the object's close method, if defined

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -20,7 +20,7 @@ from minject.inject import (
 from minject.metadata import RegistryMetadata
 from minject.mock import mock
 from minject.model import Resolvable
-from minject.registry import initialize
+from minject.registry import Registry, initialize
 
 
 class _Super:
@@ -30,6 +30,10 @@ class _Super:
 class _Sub(_Super):
     """An empty sub-class type."""
 
+class _AutostartCandidate:
+    started: bool = False
+    def __init__(self):
+        _AutostartCandidate.started = True
 
 class RegistryTestCase(unittest.TestCase):
     def setUp(self):
@@ -475,6 +479,18 @@ class RegistryTestCase(unittest.TestCase):
         # instantiated only once but accessed N times, we would see N objects for each type in the counter.
         for count in Counter(map(id, results)).values():
             self.assertEqual(count, query_per_class)
+
+
+    def test_legacy_autostart(self) -> None:
+        assert _AutostartCandidate.started == False
+        autostart_config = {
+            "registry" : {
+                "autostart" : ["tests.test_registry._AutostartCandidate"]
+            }    
+        }
+        r = Registry()
+        r.config.from_dict(autostart_config)
+        assert _AutostartCandidate.started == True
 
 
 # "Test"/check type hints.  These are not meant to be run by the unit test runner, but instead to

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -490,6 +490,8 @@ class RegistryTestCase(unittest.TestCase):
         }
         r = Registry()
         r.config.from_dict(autostart_config)
+        assert _AutostartCandidate.started == False
+        r.start()
         assert _AutostartCandidate.started == True
 
 


### PR DESCRIPTION
In order to fully replace the old `minject` codebase, we need to add some deprecated APIs back into the open source version of the tool. These are as follows:

- `registry.config.from_dict` - add config object to the registry
- Support starting objects specified in the `registry.autostart` namespace of the config file.