### PR TITLE
Add Deprecated APIs Depended on by Legacy Tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 # Changelog
 
+## v1.5.0
+
+Adds deprecated APIs depended on by legacy tools.
+
 ## v1.4.0
 
 Allow `RegistryMetadata` to process bindings for unhashable objects. If a bound

--- a/minject/__init__.py
+++ b/minject/__init__.py
@@ -44,7 +44,7 @@ registry['something_i_need'] = make_something()
 something = registry['something_i_need']
 """
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 from . import inject
 from .inject_attrs import inject_define as define, inject_field as field

--- a/minject/config.py
+++ b/minject/config.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, TypeVar, Union
 
 from typing_extensions import TypedDict
 
@@ -39,10 +39,10 @@ class RegistryConfigWrapper:
 
     def from_dict(self, config_dict: Union[Mapping[str, Any], _InternalRegistryConfig]):
         """Configure the registry from a dictionary.
-        
+
         .. deprecated:: 1.0
            This method is deprecated and should not be used in new code.
-           Use the config parameter to Registry instead to specify config dictionaries. 
+           Use the config parameter to Registry instead to specify config dictionaries.
 
         The provided dictionary should contain general configuration that can
         be accessed using the inject.config decorator. If the key 'registry'

--- a/minject/config.py
+++ b/minject/config.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 # Unbound, invariant type variable
 T = TypeVar("T")
+CONFIG_NAMESPACE = "minject"
 
 
 class RegistrySubConfig(TypedDict, total=False):
@@ -37,11 +38,18 @@ class RegistryConfigWrapper:
     def __init__(self):
         self._impl = {}
 
-    def _from_dict(self, config_dict: RegistryInitConfig):
-        """Configure the registry from a dictionary-like mapping.
-        The provided mapping should contain general configuration that can
-        be accessed using the inject.config decorator.
-
+    def from_dict(self, config_dict: Union[Dict[str, Any], InternalRegistryConfig]):
+        """Configure the registry from a dictionary.
+        The provided dictionary should contain general configuration that can
+        be accessed using the inject.config decorator. If the key 'registry'
+        is present in the dict, it will be used to configure the registry
+        itself. The following elements are recognized by the registry:
+            autostart: list of classes or names that the registry should
+                start by default.
+            by_class: dict of registry classes which map to a dict of
+                kwargs for initializing any object of that type.
+            by_name: dict of named registry entries which map to a dict of
+                kwargs for initializing that object.
         Parameters:
             config_dict: the configuration data to apply.
         """
@@ -63,25 +71,27 @@ class RegistryConfigWrapper:
         """Get init kwargs configured for a given RegistryMetadata."""
         result: Dict[str, Any] = {}
 
-        by_class = self._impl.get("by_class")
-        if by_class and meta._cls:
-            # first apply config for the class name
-            cls_name = meta._cls.__name__
-            kwargs = by_class.get(cls_name)
-            if kwargs:
-                result.update(kwargs)
+        reg_conf: Optional[RegistrySubConfig] = self._impl.get(CONFIG_NAMESPACE)
+        if reg_conf:
+            by_class = reg_conf.get("by_class")
+            if by_class and meta._cls:
+                # first apply config for the class name
+                cls_name = meta._cls.__name__
+                kwargs = by_class.get(cls_name)
+                if kwargs:
+                    result.update(kwargs)
 
-            # then apply config for the fully qualified class name
-            cls_module = f"{meta._cls.__module__}.{cls_name}"
-            kwargs = by_class.get(cls_module)
-            if kwargs:
-                result.update(kwargs)
+                # then apply config for the fully qualified class name
+                cls_module = f"{meta._cls.__module__}.{cls_name}"
+                kwargs = by_class.get(cls_module)
+                if kwargs:
+                    result.update(kwargs)
 
-        # finally apply config for the object by name
-        by_name = self._impl.get("by_name")
-        if by_name and meta._name:
-            kwargs = by_name.get(meta._name)
-            if kwargs:
-                result.update(kwargs)
+            # finally apply config for the object by name
+            by_name = reg_conf.get("by_name")
+            if by_name and meta._name:
+                kwargs = by_name.get(meta._name)
+                if kwargs:
+                    result.update(kwargs)
 
         return result

--- a/minject/config.py
+++ b/minject/config.py
@@ -37,7 +37,7 @@ class RegistryConfigWrapper:
     def __init__(self):
         self._impl = {}
 
-    def from_dict(self, config_dict: Union[Dict[str, Any], InternalRegistryConfig]):
+    def from_dict(self, config_dict: Union[Mapping[str, Any], InternalRegistryConfig]):
         """Configure the registry from a dictionary.
         The provided dictionary should contain general configuration that can
         be accessed using the inject.config decorator. If the key 'registry'

--- a/minject/config.py
+++ b/minject/config.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 # Unbound, invariant type variable
 T = TypeVar("T")
-CONFIG_NAMESPACE = "minject"
 
 
 class RegistrySubConfig(TypedDict, total=False):
@@ -71,7 +70,7 @@ class RegistryConfigWrapper:
         """Get init kwargs configured for a given RegistryMetadata."""
         result: Dict[str, Any] = {}
 
-        reg_conf: Optional[RegistrySubConfig] = self._impl.get(CONFIG_NAMESPACE)
+        reg_conf: Optional[RegistrySubConfig] = self._impl.get("registry")
         if reg_conf:
             by_class = reg_conf.get("by_class")
             if by_class and meta._cls:

--- a/minject/config.py
+++ b/minject/config.py
@@ -11,24 +11,8 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class _RegistrySubConfig(TypedDict, total=False):
-    """Configuration entries that apply to the registry itself."""
 
-    # A sequence of class names that should start at registry start time.
-    autostart: Sequence[str]
-    # Names of registry classes mapped to the kwarg dictionary that should be used to initialize
-    # the object of that type.
-    by_class: Mapping[str, Kwargs]
-    # Named registry entries that map to the kwarg dictionary that should be used to initialize
-    # the object for that name.
-    by_name: Mapping[str, Kwargs]
-
-
-class _InternalRegistryConfig(TypedDict, total=False):
-    registry: _RegistrySubConfig
-
-
-RegistryInitConfig = Union[Mapping[str, Any], _InternalRegistryConfig]
+RegistryInitConfig = Mapping[str, Any]
 
 
 class RegistryConfigWrapper:
@@ -37,23 +21,15 @@ class RegistryConfigWrapper:
     def __init__(self):
         self._impl = {}
 
-    def from_dict(self, config_dict: Union[Mapping[str, Any], _InternalRegistryConfig]):
-        """Configure the registry from a dictionary.
+    def from_dict(self, config_dict: Mapping[str, Any]):
+        """Configure the registry from a dictionary-like mapping.
+        The provided mapping should contain general configuration that can
+        be accessed using the inject.config decorator.
 
         .. deprecated:: 1.0
            This method is deprecated and should not be used in new code.
            Use the config parameter to Registry instead to specify config dictionaries.
 
-        The provided dictionary should contain general configuration that can
-        be accessed using the inject.config decorator. If the key 'registry'
-        is present in the dict, it will be used to configure the registry
-        itself. The following elements are recognized by the registry:
-            autostart: list of classes or names that the registry should
-                start by default.
-            by_class: dict of registry classes which map to a dict of
-                kwargs for initializing any object of that type.
-            by_name: dict of named registry entries which map to a dict of
-                kwargs for initializing that object.
         Parameters:
             config_dict: the configuration data to apply.
         """

--- a/minject/config.py
+++ b/minject/config.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, TypeVar
 
 from typing_extensions import TypedDict
 
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 # Unbound, invariant type variable
 T = TypeVar("T")
-
 
 
 RegistryInitConfig = Mapping[str, Any]

--- a/minject/config.py
+++ b/minject/config.py
@@ -39,6 +39,11 @@ class RegistryConfigWrapper:
 
     def from_dict(self, config_dict: Union[Mapping[str, Any], InternalRegistryConfig]):
         """Configure the registry from a dictionary.
+        
+        .. deprecated:: 1.0
+           This method is deprecated and should not be used in new code.
+           Use the config parameter to Registry instead to specify config dictionaries. 
+
         The provided dictionary should contain general configuration that can
         be accessed using the inject.config decorator. If the key 'registry'
         is present in the dict, it will be used to configure the registry
@@ -67,7 +72,13 @@ class RegistryConfigWrapper:
         return item
 
     def get_init_kwargs(self, meta: "RegistryMetadata[T]") -> Kwargs:
-        """Get init kwargs configured for a given RegistryMetadata."""
+        """Get init kwargs configured for a given RegistryMetadata.
+        
+        .. deprecated:: 1.0
+           This method is deprecated and should not be used in new code.
+           Autostart from config is considered deprecated, however we
+           must support it temporarily for backwards compatability.
+        """
         result: Dict[str, Any] = {}
 
         reg_conf: Optional[RegistrySubConfig] = self._impl.get("registry")

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -288,7 +288,7 @@ class _RegistryFunction(Deferred[T_co]):
 
     def __init__(
         self,
-        func: Union[str, Callable[..., T_co]],
+        func: Callable[..., T_co],
         # TODO: Type with ParamSpec and Concatenate after those are supported by mypy.
         #    https://github.com/python/mypy/issues/10201
         *args: DeferredAny,
@@ -305,30 +305,17 @@ class _RegistryFunction(Deferred[T_co]):
         kwargs = {}
         for key, arg in self.kwargs.items():
             kwargs[key] = resolve_value(registry_impl, arg)
-        return self.func(registry_impl)(*args, **kwargs)
+        return self.func()(*args, **kwargs)
 
     async def aresolve(self, registry_impl: Resolver) -> T_co:
         raise NotImplementedError("Have not implemented async registry function")
 
-    def func(self, registry_impl: Resolver) -> Callable[..., T_co]:
-        if isinstance(self._func, str):
-            # TODO(1.0): deprecated, unnecessary
-            # if 'func' is a string use the method with that name
-            # on the registry object referenced by arg0
-            arg0 = resolve_value(registry_impl, next(iter(self._args)))
-            return getattr(arg0, self._func)
-        else:
-            return self._func
+    def func(self) -> Callable[..., T_co]:
+        return self._func
 
     @property
     def args(self) -> Sequence[DeferredAny]:
-        if isinstance(self._func, str):
-            # TODO(1.0): deprecated, unnecessary
-            # if 'func' is a string the first argument is used to resolve the method
-            # instead of being passed as an argument
-            return self._args[1:]
-        else:
-            return self._args
+        return self._args
 
     @property
     def kwargs(self) -> Dict[str, DeferredAny]:

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -58,6 +58,12 @@ RAISE_KEY_ERROR = _RaiseKeyError()
 def bind(
     _name: Optional[str] = None, _start: None = None, _close: None = None, **bindings: DeferredAny
 ) -> Callable[[Type[T]], Type[T]]:
+    """Decorator to bind values for the init args of a class.
+    
+    .. deprecated:: 1.0
+       The _name and _start parameters are deprecated and should not be used in new code.
+       To replace _start, use a context manager instead. There is no replacement for _name.
+    """
     ...
 
 
@@ -68,7 +74,14 @@ def bind(
     _start: Optional[Callable[[T], None]] = None,
     _close: Optional[Callable[[T], None]] = None,
     **bindings: DeferredAny,
-) -> Callable[[Type[T]], Type[T]]: ...
+) -> Callable[[Type[T]], Type[T]]:
+    """Decorator to bind values for the init args of a class.
+    
+    .. deprecated:: 1.0
+       The _name and _start parameters are deprecated and should not be used in new code.
+       To replace _start, use a context manager instead. There is no replacement for _name.
+    """
+    ...
 
 
 def bind(
@@ -77,7 +90,12 @@ def bind(
     _close=None,
     **bindings,
 ):
-    """Decorator to bind values for the init args of a class."""
+    """Decorator to bind values for the init args of a class.
+    
+    .. deprecated:: 1.0
+       The _name and _start parameters are deprecated and should not be used in new code.
+       To replace _start, use a context manager instead. There is no replacement for _name.
+    """
 
     def wrap(cls: Type[T]) -> Type[T]:
         """Decorate a class with registry bindings."""
@@ -106,10 +124,16 @@ def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
     meta.is_async_context = True
     return cls
 
+
 # TODO(1.0): deprecated, not used
 def name(name_):
     # type: (str) -> Callable[[Type[T]], Type[T]]
-    """Decorator to bind a registry name for a class."""
+    """Decorator to bind a registry name for a class.
+    
+    .. deprecated:: 1.0
+       This decorator is deprecated and should not be used in new code.
+       Do not assign a name to a binding.
+    """
 
     def wrap(cls):
         # type: (Type[T]) -> Type[T]
@@ -121,10 +145,14 @@ def name(name_):
     return wrap
 
 
-# TODO(1.0): deprecated, not used
 def start_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
-    """Function to bind a registry start function for a class."""
+    """Function to bind a registry start function for a class.
+    
+    .. deprecated:: 1.0
+       This function is deprecated and should not be used in new code.
+       Use a context manager instead.
+    """
     if isinstance(cls, RegistryMetadata):
         meta = cls
     else:
@@ -132,10 +160,14 @@ def start_method(cls, method):
     meta._start = method
 
 
-# TODO(1.0): deprecated, not used
 def close_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
-    """Function to bind a registry close function for a class."""
+    """Function to bind a registry close function for a class.
+    
+    .. deprecated:: 1.0
+       This function is deprecated and should not be used in new code.
+       Use a context manager instead.
+    """
     if isinstance(cls, RegistryMetadata):
         meta = cls
     else:
@@ -150,7 +182,12 @@ def define(
     _close: Optional[Callable[[T], None]] = None,
     **bindings: DeferredAny,
 ) -> RegistryMetadata[T]:
-    """Create a new registry key based on a class and optional bindings."""
+    """Create a new registry key based on a class and optional bindings.
+    
+    .. deprecated:: 1.0
+       The _name and _start parameters are deprecated and should not be used in new code.
+       To replace _start, use a context manager instead. There is no replacement for _name.
+    """
     meta = _get_meta(base_class)
     if meta:
         meta = RegistryMetadata(
@@ -341,6 +378,11 @@ def function(
     func: Union[str, Callable[..., T]], *args: DeferredAny, **kwargs: DeferredAny
 ) -> _RegistryFunction[T]:
     """Bind a function to be run at init time.
+    
+    .. deprecated:: 1.0
+       Using a string as the func argument is deprecated and should not be used in new code.
+       Pass the function object directly instead.
+    
     Parameters:
         func: the function to call, should return a value to bind (this value
             can also be a reference). If func is a string, func will be

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -548,3 +548,7 @@ class _RegistrySelf(Deferred[Resolver]):
 
 
 self_tag = _RegistrySelf()
+
+# we must export this from minject to provide backwards
+# compatability to a legacy system
+__all__ = ["_get_meta"]

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -56,7 +56,7 @@ RAISE_KEY_ERROR = _RaiseKeyError()
 # Overload for when we _cannot_ infer what `T` will be from a call to bind
 @overload
 def bind(
-    _name: Optional[str] = None, _close: None = None, **bindings: DeferredAny
+    _name: Optional[str] = None, _start: None = None, _close: None = None, **bindings: DeferredAny
 ) -> Callable[[Type[T]], Type[T]]:
     ...
 
@@ -65,6 +65,7 @@ def bind(
 @overload
 def bind(
     _name: Optional[str] = None,
+    _start: Optional[Callable[[T], None]] = None,
     _close: Optional[Callable[[T], None]] = None,
     **bindings: DeferredAny,
 ) -> Callable[[Type[T]], Type[T]]: ...
@@ -72,6 +73,7 @@ def bind(
 
 def bind(
     _name=None,
+    _start=None,
     _close=None,
     **bindings,
 ):
@@ -82,6 +84,8 @@ def bind(
         meta = _gen_meta(cls)
         if _name:
             meta._name = _name
+        if _start:
+            meta._start = _start
         if _close:
             meta._close = _close
         meta.update_bindings(**bindings)
@@ -118,6 +122,17 @@ def name(name_):
 
 
 # TODO(1.0): deprecated, not used
+def start_method(cls, method):
+    # type: (Type[T], Callable[[T], None]) -> None
+    """Function to bind a registry start function for a class."""
+    if isinstance(cls, RegistryMetadata):
+        meta = cls
+    else:
+        meta = _gen_meta(cls)
+    meta._start = method
+
+
+# TODO(1.0): deprecated, not used
 def close_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
     """Function to bind a registry close function for a class."""
@@ -131,6 +146,7 @@ def close_method(cls, method):
 def define(
     base_class: Type[T],
     _name: Optional[str] = None,
+    _start: Optional[Callable[[T], None]] = None,
     _close: Optional[Callable[[T], None]] = None,
     **bindings: DeferredAny,
 ) -> RegistryMetadata[T]:
@@ -144,6 +160,7 @@ def define(
     else:
         meta = RegistryMetadata(base_class, bindings=bindings)
     meta._name = _name
+    meta._start = _start
     meta._close = _close
     return meta
 
@@ -246,7 +263,7 @@ def reference(key, **bindings):
     if not bindings:
         return _RegistryReference(key)
     elif isinstance(key, type):
-        return _RegistryReference(define(key, None, None, **bindings))
+        return _RegistryReference(define(key, None, None, None, **bindings))
     else:
         raise TypeError("inject.reference can only include bindings on classes")
 

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -125,26 +125,6 @@ def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
     return cls
 
 
-# TODO(1.0): deprecated, not used
-def name(name_):
-    # type: (str) -> Callable[[Type[T]], Type[T]]
-    """Decorator to bind a registry name for a class.
-    
-    .. deprecated:: 1.0
-       This decorator is deprecated and should not be used in new code.
-       Do not assign a name to a binding.
-    """
-
-    def wrap(cls):
-        # type: (Type[T]) -> Type[T]
-        """Decorate a class with a registry name."""
-        meta = _gen_meta(cls)
-        meta._name = name_
-        return cls
-
-    return wrap
-
-
 def start_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
     """Function to bind a registry start function for a class.

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -59,12 +59,11 @@ def bind(
     _name: Optional[str] = None, _start: None = None, _close: None = None, **bindings: DeferredAny
 ) -> Callable[[Type[T]], Type[T]]:
     """Decorator to bind values for the init args of a class.
-    
+
     .. deprecated:: 1.0
        The _name and _start parameters are deprecated and should not be used in new code.
        To replace _start, use a context manager instead. There is no replacement for _name.
     """
-    ...
 
 
 # Overload for when we _can_ infer what `T` will be from a call to bind.
@@ -76,12 +75,11 @@ def bind(
     **bindings: DeferredAny,
 ) -> Callable[[Type[T]], Type[T]]:
     """Decorator to bind values for the init args of a class.
-    
+
     .. deprecated:: 1.0
        The _name and _start parameters are deprecated and should not be used in new code.
        To replace _start, use a context manager instead. There is no replacement for _name.
     """
-    ...
 
 
 def bind(
@@ -91,7 +89,7 @@ def bind(
     **bindings,
 ):
     """Decorator to bind values for the init args of a class.
-    
+
     .. deprecated:: 1.0
        The _name and _start parameters are deprecated and should not be used in new code.
        To replace _start, use a context manager instead. There is no replacement for _name.
@@ -128,7 +126,7 @@ def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
 def start_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
     """Function to bind a registry start function for a class.
-    
+
     .. deprecated:: 1.0
        This function is deprecated and should not be used in new code.
        Use a context manager instead.
@@ -143,7 +141,7 @@ def start_method(cls, method):
 def close_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
     """Function to bind a registry close function for a class.
-    
+
     .. deprecated:: 1.0
        This function is deprecated and should not be used in new code.
        Use a context manager instead.
@@ -163,7 +161,7 @@ def define(
     **bindings: DeferredAny,
 ) -> RegistryMetadata[T]:
     """Create a new registry key based on a class and optional bindings.
-    
+
     .. deprecated:: 1.0
        The _name and _start parameters are deprecated and should not be used in new code.
        To replace _start, use a context manager instead. There is no replacement for _name.
@@ -358,11 +356,11 @@ def function(
     func: Union[str, Callable[..., T]], *args: DeferredAny, **kwargs: DeferredAny
 ) -> _RegistryFunction[T]:
     """Bind a function to be run at init time.
-    
+
     .. deprecated:: 1.0
        Using a string as the func argument is deprecated and should not be used in new code.
        Pass the function object directly instead.
-    
+
     Parameters:
         func: the function to call, should return a value to bind (this value
             can also be a reference). If func is a string, func will be

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -343,13 +343,20 @@ def function(
     func: Callable[..., T], *args: DeferredAny, **kwargs: DeferredAny
 ) -> _RegistryFunction[T]:
     """Bind a function to be run at init time.
-
     Parameters:
         func: the function to call, should return a value to bind (this value
-            can also be a reference).
+            can also be a reference). If func is a string, func will be
+            determined by calling getattr on the first positional argument.
         args: positional arguments that should be passed to the function.
         kwargs: keyword arguments that should be passed to the function.
     """
+    if isinstance(func, str):
+        if not args:
+            raise ValueError(
+                "registry.function using a string must have a "
+                "positional argument to call getattr on"
+            )
+
     return _RegistryFunction(func, *args, **kwargs)
 
 

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -125,7 +125,8 @@ def async_context(cls: Type[T_async_context]) -> Type[T_async_context]:
 
 def start_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
-    """Function to bind a registry start function for a class.
+    """Function to bind a registry start function for a class. Throws
+       ValueError if the start function is already set.
 
     .. deprecated:: 1.0
        This function is deprecated and should not be used in new code.
@@ -135,12 +136,17 @@ def start_method(cls, method):
         meta = cls
     else:
         meta = _gen_meta(cls)
+
+    if meta._start is not None:
+        raise ValueError("Cannot modify start with decorator if it is already set")
+
     meta._start = method
 
 
 def close_method(cls, method):
     # type: (Type[T], Callable[[T], None]) -> None
-    """Function to bind a registry close function for a class.
+    """Function to bind a registry close function for a class. Throws
+       ValueError if the close function is already set.
 
     .. deprecated:: 1.0
        This function is deprecated and should not be used in new code.
@@ -150,6 +156,10 @@ def close_method(cls, method):
         meta = cls
     else:
         meta = _gen_meta(cls)
+
+    if meta._close is not None:
+        raise ValueError("Cannot modify close with decorator if it is already set")
+
     meta._close = method
 
 

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -511,4 +511,16 @@ self_tag = _RegistrySelf()
 
 # we must export this from minject to provide backwards
 # compatability to a legacy system
-__all__ = ["_get_meta"]
+__all__ = [
+    "_get_meta",
+    "bind",
+    "config",
+    "nested_config",
+    "define",
+    "function",
+    "reference",
+    "self_tag",
+    "start_method", # deprecated
+    "close_method", # deprecated
+    "async_context",
+]

--- a/minject/inject.py
+++ b/minject/inject.py
@@ -353,28 +353,16 @@ class _RegistryFunction(Deferred[T_co]):
 
 
 def function(
-    func: Union[str, Callable[..., T]], *args: DeferredAny, **kwargs: DeferredAny
+    func: Callable[..., T], *args: DeferredAny, **kwargs: DeferredAny
 ) -> _RegistryFunction[T]:
     """Bind a function to be run at init time.
 
-    .. deprecated:: 1.0
-       Using a string as the func argument is deprecated and should not be used in new code.
-       Pass the function object directly instead.
-
     Parameters:
         func: the function to call, should return a value to bind (this value
-            can also be a reference). If func is a string, func will be
-            determined by calling getattr on the first positional argument.
+            can also be a reference).
         args: positional arguments that should be passed to the function.
         kwargs: keyword arguments that should be passed to the function.
     """
-    if isinstance(func, str):
-        if not args:
-            raise ValueError(
-                "registry.function using a string must have a "
-                "positional argument to call getattr on"
-            )
-
     return _RegistryFunction(func, *args, **kwargs)
 
 

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -114,7 +114,6 @@ class RegistryMetadata(Generic[T_co]):
         self._cls = cls
         self._bindings = bindings or {}
 
-        # TODO(1.0): deprecated, not used
         self._name = name
         self._start = start
         self._close = close

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -128,7 +128,11 @@ class RegistryMetadata(Generic[T_co]):
 
     @property
     def name(self) -> Optional[str]:
-        """Get the name this object is stored as in the registry."""
+        """
+        .. deprecated:: 1.0
+            This property is deprecated and should not be used in new code.
+            Do not assign a name to a binding.
+        """
         return self._name
 
     @name.setter
@@ -143,7 +147,7 @@ class RegistryMetadata(Generic[T_co]):
     @property
     def key(self) -> Hashable:
         """The unique identifier used by this registry object.
-        By default this is a combination of class and bindings.
+        This is a combination of class and bindings.
         """
         if self._key is None:
             self._key = self._gen_key()

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -196,11 +196,6 @@ class RegistryMetadata(Generic[T_co]):
         for name_, value in self._bindings.items():
             init_kwargs[name_] = resolve_value(registry_impl, value)
 
-        config_ = registry_impl.config.get_init_kwargs(self)
-        if config_:
-            for name_, value in config_.items():
-                init_kwargs[name_] = value
-
         self._cls.__init__(obj, **init_kwargs)
 
     async def _ainit_object(self, obj: T_co, registry_impl: "Registry") -> None:  # type: ignore[misc]

--- a/minject/metadata.py
+++ b/minject/metadata.py
@@ -111,6 +111,10 @@ class RegistryMetadata(Generic[T_co]):
         is_async_context: bool = False,
         key: Optional[Hashable] = None,
     ):
+        """
+        .. deprecated:: 1.0
+            The `name`, `start`, `close`, are deprecated and should not be used in new code.
+        """
         self._cls = cls
         self._bindings = bindings or {}
 

--- a/minject/mock.py
+++ b/minject/mock.py
@@ -40,7 +40,7 @@ def mock(key: "RegistryKey[T]", mocking_function: Optional[MockingFunction] = No
         class_instantiated_with_mocks = iface(**kwargs_to_mocks)
     except TypeError:
         raise TypeError(
-            f"Unable to instantiate class {meta_to_mock.key}"
+            f"Unable to instantiate class {meta_to_mock.name}"
             "with mocks. Provided arguments do not match class"
             "signature.\n"
             f"arguments: {kwargs_to_mocks}\n"

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -13,7 +13,7 @@ from typing_extensions import ParamSpec
 
 from minject.inject import _is_key_async, _RegistryReference, reference
 
-from .config import RegistryConfigWrapper, RegistryInitConfig, RegistrySubConfig
+from .config import CONFIG_NAMESPACE, RegistryConfigWrapper, RegistryInitConfig, RegistrySubConfig
 from .metadata import RegistryMetadata, _get_meta, _get_meta_from_key
 from .model import RegistryKey, Resolvable, Resolver, aresolve_value, resolve_value
 
@@ -35,10 +35,10 @@ class _AutoOrNone:
 AUTO_OR_NONE = _AutoOrNone()
 
 
-def initialize(config: Optional[RegistryInitConfig] = None) -> "Registry":
+def initialize() -> "Registry":
     """Initialize a new registry instance."""
     LOG.debug("initializing a new registry instance")
-    return Registry(config)
+    return Registry()
 
 
 def _unwrap(wrapper: Optional["RegistryWrapper[T]"]) -> Optional[T]:
@@ -86,20 +86,18 @@ def _synchronized(
 class Registry(Resolver):
     """Tracks and manages registered object instances."""
 
-    def __init__(self, config: Optional[RegistryInitConfig] = None):
+    def __init__(self):
         self._objects: List[RegistryWrapper] = []
         self._by_meta: Dict[RegistryMetadata, RegistryWrapper] = {}
         self._by_name: Dict[str, RegistryWrapper] = {}
         self._by_iface: Dict[type, List[RegistryWrapper]] = {}
+
         self._config = RegistryConfigWrapper()
 
         self._lock = RLock()
 
         self._async_context_stack: AsyncExitStack = AsyncExitStack()
         self._async_entered = False
-
-        if config is not None:
-            self._config._from_dict(config)
 
     @property
     def config(self) -> RegistryConfigWrapper:
@@ -129,12 +127,11 @@ class Registry(Resolver):
             )
 
     def _autostart_candidates(self) -> Iterable[RegistryKey]:
-        # the autostart_default variable exists so that the
-        # autostart variable can be type hinted
-        autostart_default: Optional[Iterable[str]] = None
-        autostart = self.config.get(key="autostart", default=autostart_default)
-        if autostart:
-            return (_resolve_import(value) for value in autostart)
+        registry_config: Optional[RegistrySubConfig] = self.config.get(CONFIG_NAMESPACE)
+        if registry_config:
+            autostart = registry_config.get("autostart")
+            if autostart:
+                return (_resolve_import(value) for value in autostart)
         return ()
 
     @_synchronized

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -7,9 +7,9 @@ from asyncio import to_thread
 from contextlib import AsyncExitStack
 from textwrap import dedent
 from threading import RLock
-from typing import Any, Callable, Concatenate, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, Concatenate
 
 from minject.inject import _is_key_async, _RegistryReference, reference
 

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -9,11 +9,11 @@ from textwrap import dedent
 from threading import RLock
 from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import ParamSpec
 
 from minject.inject import _is_key_async, _RegistryReference, reference
 
-from .config import RegistryConfigWrapper, RegistryInitConfig
+from .config import RegistryConfigWrapper, RegistryInitConfig, RegistrySubConfig
 from .metadata import RegistryMetadata, _get_meta, _get_meta_from_key
 from .model import RegistryKey, Resolvable, Resolver, aresolve_value, resolve_value
 
@@ -58,10 +58,16 @@ class RegistryWrapper(Generic[T]):
         self.obj = obj
         self._meta = _meta
 
+    def start(self) -> None:
+        if not getattr(self, "_started", False) and self._meta:
+            self._meta._start_object(self.obj)
+        self._started = True
+
     def close(self) -> None:
-        if not getattr(self, "_closed", False) and self._meta:
-            self._meta._close_object(self.obj)
-        self._closed = True
+        if getattr(self, "_started", False):
+            if not getattr(self, "_closed", False) and self._meta:
+                self._meta._close_object(self.obj)
+            self._closed = True
 
 
 def _synchronized(
@@ -70,7 +76,7 @@ def _synchronized(
     """Decorator to synchronize method access with a reentrant lock."""
 
     @functools.wraps(func)
-    def wrapper(self: "Registry", *args: P.args, **kwargs: P.kwargs) -> R:
+    def wrapper(self: "Registry", *args: Any, **kwargs: Any) -> R:
         with self._lock:
             return func(self, *args, **kwargs)
 
@@ -121,6 +127,30 @@ class Registry(Resolver):
                 """
                 ).strip()
             )
+
+    def _autostart_candidates(self) -> Iterable[RegistryKey]:
+        # the autostart_default variable exists so that the
+        # autostart variable can be type hinted
+        autostart_default: Optional[Iterable[str]] = None
+        autostart = self.config.get(key="autostart", default=autostart_default)
+        if autostart:
+            return (_resolve_import(value) for value in autostart)
+        return ()
+
+    @_synchronized
+    def start(self) -> None:
+        """
+        Call start if defined on all objects contained in the registry.
+        This includes any classes designated as autostart in config.
+        """
+        for key in self._autostart_candidates():
+            LOG.debug("autostarting %s", key)
+            self[key]  # pylint: disable=pointless-statement
+
+        for wrapper in list(self._objects):
+            if wrapper._meta is not None:
+                # call the object's start method, if defined
+                wrapper.start()
 
     @_synchronized
     def close(self) -> None:
@@ -210,6 +240,8 @@ class Registry(Resolver):
             # add to our list of all objects (this MUST happen after init so
             # any references come earlier in sequence and are destroyed first)
             self._objects.append(wrapper)
+            # call start method (if any)
+            wrapper.start()
             success = True
         finally:
             if not success:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -7,13 +7,13 @@ from asyncio import to_thread
 from contextlib import AsyncExitStack
 from textwrap import dedent
 from threading import RLock
-from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Dict, Generic, Iterable, List, Mapping, Optional, TypeVar, Union, cast
 
 from typing_extensions import Concatenate, ParamSpec
 
 from minject.inject import _is_key_async, _RegistryReference, reference
 
-from .config import RegistryConfigWrapper, RegistryInitConfig, _RegistrySubConfig
+from .config import RegistryConfigWrapper, RegistryInitConfig
 from .metadata import RegistryMetadata, _get_meta, _get_meta_from_key
 from .model import RegistryKey, Resolvable, Resolver, aresolve_value, resolve_value
 
@@ -129,7 +129,7 @@ class Registry(Resolver):
             )
 
     def _autostart_candidates(self) -> Iterable[RegistryKey]:
-        registry_config: Optional[_RegistrySubConfig] = self.config.get("registry")
+        registry_config: Mapping[str, Any] = self.config.get("registry")
         if registry_config:
             autostart = registry_config.get("autostart")
             if autostart:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -87,10 +87,10 @@ class Registry(Resolver):
     """Tracks and manages registered object instances."""
 
     def __init__(self, config: Optional[RegistryInitConfig] = None):
-        self._objects: List[_RegistryWrapper] = []
-        self._by_meta: Dict[RegistryMetadata, _RegistryWrapper] = {}
-        self._by_name: Dict[str, _RegistryWrapper] = {}
-        self._by_iface: Dict[type, List[_RegistryWrapper]] = {}
+        self._objects: List[_RegistryWrapper[Any]] = []
+        self._by_meta: Dict[RegistryMetadata, _RegistryWrapper[Any]] = {}
+        self._by_name: Dict[str, _RegistryWrapper[Any]] = {}
+        self._by_iface: Dict[type, List[_RegistryWrapper[Any]]] = {}
         self._config = RegistryConfigWrapper()
 
         self._lock = RLock()
@@ -328,7 +328,7 @@ class Registry(Resolver):
     def __len__(self) -> int:
         return len(self._objects)
 
-    def __contains__(self, key) -> bool:
+    def __contains__(self, key : object) -> bool:
         """Check if an object is contained in the registry.
         Note that this method returns True if the object has already been
         registered. It is possible that the key provides enough information

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -13,7 +13,7 @@ from typing_extensions import ParamSpec
 
 from minject.inject import _is_key_async, _RegistryReference, reference
 
-from .config import CONFIG_NAMESPACE, RegistryConfigWrapper, RegistryInitConfig, RegistrySubConfig
+from .config import RegistryConfigWrapper, RegistryInitConfig, RegistrySubConfig
 from .metadata import RegistryMetadata, _get_meta, _get_meta_from_key
 from .model import RegistryKey, Resolvable, Resolver, aresolve_value, resolve_value
 
@@ -127,7 +127,7 @@ class Registry(Resolver):
             )
 
     def _autostart_candidates(self) -> Iterable[RegistryKey]:
-        registry_config: Optional[RegistrySubConfig] = self.config.get(CONFIG_NAMESPACE)
+        registry_config: Optional[RegistrySubConfig] = self.config.get("registry")
         if registry_config:
             autostart = registry_config.get("autostart")
             if autostart:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -86,7 +86,7 @@ def _synchronized(
 class Registry(Resolver):
     """Tracks and manages registered object instances."""
 
-    def __init__(self):
+    def __init__(self, config: Optional[RegistryInitConfig] = None):
         self._objects: List[RegistryWrapper] = []
         self._by_meta: Dict[RegistryMetadata, RegistryWrapper] = {}
         self._by_name: Dict[str, RegistryWrapper] = {}
@@ -98,6 +98,9 @@ class Registry(Resolver):
 
         self._async_context_stack: AsyncExitStack = AsyncExitStack()
         self._async_entered = False
+
+        if config is not None:
+             self._config.from_dict(config)
 
     @property
     def config(self) -> RegistryConfigWrapper:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -13,7 +13,7 @@ from typing_extensions import Concatenate, ParamSpec
 
 from minject.inject import _is_key_async, _RegistryReference, reference
 
-from .config import RegistryConfigWrapper, RegistryInitConfig, RegistrySubConfig
+from .config import RegistryConfigWrapper, RegistryInitConfig, _RegistrySubConfig
 from .metadata import RegistryMetadata, _get_meta, _get_meta_from_key
 from .model import RegistryKey, Resolvable, Resolver, aresolve_value, resolve_value
 
@@ -129,7 +129,7 @@ class Registry(Resolver):
             )
 
     def _autostart_candidates(self) -> Iterable[RegistryKey]:
-        registry_config: Optional[RegistrySubConfig] = self.config.get("registry")
+        registry_config: Optional[_RegistrySubConfig] = self.config.get("registry")
         if registry_config:
             autostart = registry_config.get("autostart")
             if autostart:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -129,10 +129,9 @@ class Registry(Resolver):
             )
 
     def _autostart_candidates(self) -> Iterable[RegistryKey]:
-        registry_config: Mapping[str, Any] = self.config.get("registry")
-        if registry_config:
-            autostart = registry_config.get("autostart")
-            if autostart:
+        registry_config: Optional[Mapping[str, Any]] = self.config.get("registry")
+        if registry_config is not None:
+            if (autostart := registry_config.get("autostart")) is not None:
                 return (_resolve_import(value) for value in autostart)
         return ()
 
@@ -148,7 +147,7 @@ class Registry(Resolver):
         """
         for key in self._autostart_candidates():
             LOG.debug("autostarting %s", key)
-            self[key]  # pylint: disable=pointless-statement
+            _ = self[key]
 
         for wrapper in list(self._objects):
             if wrapper._meta is not None:

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -141,7 +141,7 @@ class Registry(Resolver):
         """
         Call start if defined on all objects contained in the registry.
         This includes any classes designated as autostart in config.
-        
+
         .. deprecated:: 1.0
            This method is deprecated and should not be used in new code.
            Use the context manager API instead.
@@ -158,7 +158,7 @@ class Registry(Resolver):
     @_synchronized
     def close(self) -> None:
         """Close all objects contained in the registry.
-        
+
         .. deprecated:: 1.0
            This method is deprecated and should not be used in new code.
            Use the context manager API instead.
@@ -304,9 +304,8 @@ class Registry(Resolver):
         if meta.name:
             if meta.name in self._by_name:
                 return self._by_name[meta.name]
-        else:
-            if meta in self._by_meta:
-                return self._by_meta[meta]
+        elif meta in self._by_meta:
+            return self._by_meta[meta]
 
         if default is AUTO_OR_NONE:
             return self._register_by_metadata(meta)

--- a/minject/registry.py
+++ b/minject/registry.py
@@ -7,7 +7,7 @@ from asyncio import to_thread
 from contextlib import AsyncExitStack
 from textwrap import dedent
 from threading import RLock
-from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Concatenate, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 from typing_extensions import ParamSpec
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -538,7 +538,7 @@ class RegistryTestCase(unittest.TestCase):
         class NamedClass:
             def __init__(self):
                 pass
-        
+
         # Verify functionality still works
         registry = initialize()
         instance = registry[NamedClass]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -429,8 +429,7 @@ class RegistryTestCase(unittest.TestCase):
             base.closed = True
 
         @bind(_start=start, _close=close)
-        class Sub(Base):
-            ...
+        class Sub(Base): ...
 
         # Registry starts on initial lookup as part of the initiation process
         instance = self.registry[Sub]
@@ -531,6 +530,20 @@ class RegistryTestCase(unittest.TestCase):
         # instantiated only once but accessed N times, we would see N objects for each type in the counter.
         for count in Counter(map(id, results)).values():
             self.assertEqual(count, query_per_class)
+
+    def test_bind_name_parameter(self) -> None:
+        """Test that the _name parameter of inject.bind() works correctly and emits a deprecation warning."""
+
+        @bind(_name="test_name")
+        class NamedClass:
+            def __init__(self):
+                pass
+        
+        # Verify functionality still works
+        registry = initialize()
+        instance = registry[NamedClass]
+        self.assertIsInstance(instance, NamedClass)
+        self.assertEqual(registry["test_name"], instance)
 
 
 # "Test"/check type hints.  These are not meant to be run by the unit test runner, but instead to

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -186,6 +186,9 @@ class RegistryTestCase(unittest.TestCase):
         func_ref = function(helpers.passthrough, other=reference(other))
         self.assertEqual(((), {"other": registry[other]}), func_ref.call(registry))
 
+        func_factory: _RegistryFunction[str] = function("create", reference(helpers.Factory), 1)
+        self.assertEqual("1", func_factory.call(registry))
+
         func = function(helpers.passthrough)
         self.assertEqual(((), {}), func.call(registry))
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -174,59 +174,23 @@ class RegistryTestCase(unittest.TestCase):
 
         self.assertEqual("http://localhost/myapi", client.get())
 
-    def test_config(self) -> None:
-        RedBorder = define(helpers.Border, color="red")
-        RedBorder.name = "border_red"
-
-        DottedBorder = define(helpers.Border)
-        DottedBorder.name = "border_dotted"
-
-        self.registry.config.from_dict(
-            {
-                "registry": {
-                    "by_class": {"tests.test_registry_helpers.Border": {"style": "solid"}},
-                    "by_name": {
-                        "border_red": {"width": "2px"},
-                        "border_dotted": {"style": "dotted"},
-                    },
-                }
-            }
-        )
-
-        border = self.registry[helpers.Border]
-        border_red = self.registry[RedBorder]
-        border_dotted = self.registry[DottedBorder]
-
-        self.assertEqual("1px", border.width)
-        self.assertEqual("2px", border_red.width)
-        self.assertEqual("1px", border_dotted.width)
-        self.assertEqual("solid", border.style)
-        self.assertEqual("solid", border_red.style)
-        self.assertEqual("dotted", border_dotted.style)
-        self.assertEqual("black", border.color)
-        self.assertEqual("red", border_red.color)
-        self.assertEqual("black", border_dotted.color)
-
     def test_func(self) -> None:
-        func = function(helpers.passthrough)
-        self.assertEqual(((), {}), func.call(self.registry))
-
-        func_simple = function(helpers.passthrough, 1, a="b")
-        self.assertEqual(((1,), {"a": "b"}), func_simple.call(self.registry))
-
-        self.registry.config.from_dict({"arg0": "val0", "value": "val_name"})
+        registry = initialize({"arg0": "val0", "value": "val_name"})
         func_config = function(helpers.passthrough, config("arg0"), name=config("value"))
-        self.assertEqual((("val0",), {"name": "val_name"}), func_config.call(self.registry))
+        self.assertEqual((("val0",), {"name": "val_name"}), func_config.call(registry))
 
         func_nested = function(helpers.passthrough, function(helpers.nested, 2))
-        self.assertEqual(((2,), {}), func_nested.call(self.registry))
+        self.assertEqual(((2,), {}), func_nested.call(registry))
 
         other = define(object)
         func_ref = function(helpers.passthrough, other=reference(other))
-        self.assertEqual(((), {"other": self.registry[other]}), func_ref.call(self.registry))
+        self.assertEqual(((), {"other": registry[other]}), func_ref.call(registry))
 
-        func_factory: _RegistryFunction[str] = function("create", reference(helpers.Factory), 1)
-        self.assertEqual("1", func_factory.call(self.registry))
+        func = function(helpers.passthrough)
+        self.assertEqual(((), {}), func.call(registry))
+
+        func_simple = function(helpers.passthrough, 1, a="b")
+        self.assertEqual(((1,), {"a": "b"}), func_simple.call(registry))
 
     def test_mock(self) -> None:
         """Test canonical usage of mock"""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -496,7 +496,7 @@ class RegistryTestCase(unittest.TestCase):
             self.assertEqual(count, query_per_class)
 
     def test_bind_name_parameter(self) -> None:
-        """Test that the _name parameter of inject.bind() works correctly and emits a deprecation warning."""
+        """Test that the _name parameter of inject.bind() works correctly"""
 
         @bind(_name="test_name")
         class NamedClass:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -183,7 +183,7 @@ class RegistryTestCase(unittest.TestCase):
 
         self.registry.config.from_dict(
             {
-                "minject": {
+                "registry": {
                     "by_class": {"tests.test_registry_helpers.Border": {"style": "solid"}},
                     "by_name": {
                         "border_red": {"width": "2px"},
@@ -401,7 +401,7 @@ class RegistryTestCase(unittest.TestCase):
 
     def test_autostart(self) -> None:
         self.registry.config.from_dict(
-            {"minject": {"autostart": ["tests.test_registry_helpers.FakeWorker"]}}
+            {"registry": {"autostart": ["tests.test_registry_helpers.FakeWorker"]}}
         )
 
         self.registry.start()

--- a/tests/test_registry_helpers.py
+++ b/tests/test_registry_helpers.py
@@ -99,6 +99,9 @@ class FakeWorker:
         self._closed = True
 
 
+inject.close_method(FakeWorker, FakeWorker.close)
+
+
 def logic(registry_impl):
     return registry_impl
 

--- a/tests/test_registry_helpers.py
+++ b/tests/test_registry_helpers.py
@@ -95,10 +95,14 @@ class FakeWorker:
     def __init__(self):
         FakeWorker.instance = self
 
+    def start(self):
+        self._started = True
+
     def close(self):
         self._closed = True
 
 
+inject.start_method(FakeWorker, FakeWorker.start)
 inject.close_method(FakeWorker, FakeWorker.close)
 
 

--- a/tests/test_start_close.py
+++ b/tests/test_start_close.py
@@ -1,5 +1,6 @@
 import unittest
 
+from minject import inject
 from minject.inject import close_method, start_method
 from minject.registry import initialize
 
@@ -99,3 +100,32 @@ class TestStartStopDecorators(unittest.TestCase):
         # Verify the close function was called
         self.assertTrue(self.close_called)
         self.assertEqual(instance.value, 2)
+
+    def test_start_method_decorator_duplicate(self) -> None:
+        """Test that start_method decorator correctly sets up a start function."""
+
+        def start_func(obj : "TestClass") -> None:
+            ...
+
+        def close_func(obj : "TestClass") -> None:
+            ...
+
+        @inject.bind(_start=start_func, _close=close_func)
+        class TestClass:
+            def __init__(self) -> None:
+                self.value = 0
+
+            def increment(self) -> None:
+                self.value += 1
+
+            def noop(self) -> None:
+                pass
+
+        # assert raises ValueError
+        with self.assertRaises(ValueError):
+            start_method(TestClass, lambda x: x.noop())
+
+        with self.assertRaises(ValueError):
+            close_method(TestClass, lambda x: x.noop())
+
+

--- a/tests/test_start_close.py
+++ b/tests/test_start_close.py
@@ -1,0 +1,101 @@
+import unittest
+
+from minject.inject import close_method, start_method
+from minject.registry import initialize
+
+
+class TestStartStopDecorators(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = initialize()
+        self.start_called = False
+        self.close_called = False
+
+    def test_start_method(self) -> None:
+        """Test that start_method decorator correctly sets up a start function."""
+
+        class TestClass:
+            def __init__(self) -> None:
+                self.value = 0
+
+            def increment(self) -> None:
+                self.value += 1
+
+        def start_func(obj: TestClass) -> None:
+            self.start_called = True
+            obj.increment()
+
+        # Apply the start_method decorator
+        start_method(TestClass, start_func)
+
+        # Create an instance through the registry
+        instance = self.registry[TestClass]
+
+        # Verify the start function was called
+        self.assertTrue(self.start_called)
+        self.assertEqual(instance.value, 1)
+
+    def test_close_method(self) -> None:
+        """Test that close_method decorator correctly sets up a close function."""
+
+        class TestClass:
+            def __init__(self) -> None:
+                self.value = 0
+
+            def increment(self) -> None:
+                self.value += 1
+
+        def close_func(obj: TestClass) -> None:
+            self.close_called = True
+            obj.increment()
+
+        self.assertFalse(self.close_called)
+
+        # Apply the close_method decorator
+        close_method(TestClass, close_func)
+
+        # Create an instance through the registry
+        instance = self.registry[TestClass]
+
+        # Close the registry
+        self.registry.close()
+
+        # Verify the close function was called
+        self.assertTrue(self.close_called)
+        self.assertEqual(instance.value, 1)
+
+    def test_start_and_close_methods(self) -> None:
+        """Test that both start and close methods work together."""
+
+        class TestClass:
+            def __init__(self) -> None:
+                self.value = 0
+
+            def increment(self) -> None:
+                self.value += 1
+
+        def start_func(obj: TestClass) -> None:
+            self.start_called = True
+            obj.increment()
+
+        def close_func(obj: TestClass) -> None:
+            self.close_called = True
+            obj.increment()
+
+        # Apply both decorators
+        start_method(TestClass, start_func)
+        close_method(TestClass, close_func)
+
+        # Create an instance through the registry
+        instance = self.registry[TestClass]
+
+        # Verify the start function was called
+        self.assertTrue(self.start_called)
+        self.assertEqual(instance.value, 1)
+        self.assertFalse(self.close_called)
+
+        # Close the registry
+        self.registry.close()
+
+        # Verify the close function was called
+        self.assertTrue(self.close_called)
+        self.assertEqual(instance.value, 2)


### PR DESCRIPTION
This PR is essentially a revert of the following four commits, being careful to only re-add features that are currently depended on:

- https://github.com/duolingo/minject/commit/b57ff263bf7953971fcf4a41207dd270fc0be2b2
- https://github.com/duolingo/minject/commit/6618e0234a221f3e56b88f623a5159f6503afb27
- https://github.com/duolingo/minject/commit/27a3977e6ee8b0deb0da0eca7c67d459a353af56
- https://github.com/duolingo/minject/commit/05e005bf2630e6e22d53d6bb665a9f96ee32fee4

This PR adds the following deprecated APIs to allow the Public version of this project to fully replace the private version.

The depreacted APIs we are adding are as follows:

- Initialize classes specified in the `registry.autostart` namespace in a config file
- Adding the `_name` and `_start` parameters back into the `inject.bind()` + `inject.define()` functions, allowing you to rename a binding in the registry and define a method to call when the binding is first initialized.
- Adding `Registry.start` back in
- Adding `start_method` + `close_method` decorators back in
- Adding the `registry.config.from_dict` method back in

**NONE OF THESE APIS SHOULD BE USED BY ANY NEW CODE!!!!**

I am not adding the following deprecated APIs back in as they do not appear to be used:

- `inject.name`
- `config.RegistrySubConfig`
- `config.InternalRegistryConfig`
- Initializing classes using the `registry.by_class` and `registry.by_name` namespaces

**Semi-Related Change** - I am also making the `RegistryWrapper` class private. It is not referenced outside the library and as far as I can tell it has no reason to be. This also allows us to not mark aspects of the class as deprecated, as it is private.